### PR TITLE
Fix OLS residual dimnames

### DIFF
--- a/R/ndx_utils.R
+++ b/R/ndx_utils.R
@@ -41,7 +41,9 @@ calculate_residuals_ols <- function(Y, X) {
 
   # stats::lm.fit is efficient for multiple response variables (columns in Y)
   fit <- stats::lm.fit(X, Y)
-  return(fit$residuals)
+  res <- fit$residuals
+  dimnames(res) <- NULL
+  return(res)
 }
 
 #' Calculate Voxel-wise R-squared


### PR DESCRIPTION
## Summary
- ensure calculate_residuals_ols removes dimnames from OLS residual matrix

## Testing
- `Rscript run_tests.R` *(fails: `bash: Rscript: command not found`)*