### PR TITLE
Add defaults for HRF options and relax validation

### DIFF
--- a/R/ndx_hrf.R
+++ b/R/ndx_hrf.R
@@ -402,15 +402,17 @@ cv_fusedlasso <- function(y, X, lambda_grid, gamma_grid, k_folds, block_ids) {
 validate_hrf_inputs <- function(Y_fmri, pass0_residuals, events, run_idx, TR, spike_TR_mask, user_options) {
   if (missing(user_options)) stop("user_options are required for HRF estimation.")
   
-  default_opts <- list(return_full_model = FALSE) # Add other defaults if any arise
+  default_opts <- list(
+    hrf_fir_taps = 12L,
+    hrf_fir_span_seconds = 24,
+    good_voxel_R2_threshold = 0.05,
+    cv_folds = 5L,
+    lambda1_grid = 10^seq(-2, 1, length.out = 5),
+    lambda2_grid = 10^seq(-3, 0, length.out = 5),
+    hrf_min_good_voxels = 50L,
+    return_full_model = FALSE
+  )
   user_options <- utils::modifyList(default_opts, user_options)
-
-  expected_opts_names <- c("hrf_fir_taps", "hrf_fir_span_seconds", "good_voxel_R2_threshold",
-                           "cv_folds", "lambda1_grid", "lambda2_grid", "hrf_min_good_voxels", "return_full_model")
-  if(!all(expected_opts_names %in% names(user_options))) {
-    stop(paste("Missing one or more user_options for HRF estimation:", 
-               paste(expected_opts_names[!expected_opts_names %in% names(user_options)], collapse=", ")))
-  }
 
   if (!is.matrix(Y_fmri) || !is.numeric(Y_fmri)) stop("Y_fmri must be a numeric matrix.")
   n_timepoints <- nrow(Y_fmri)

--- a/R/ndx_workflow.R
+++ b/R/ndx_workflow.R
@@ -52,9 +52,21 @@ ndx_run_sprint1 <- function(Y_fmri,
   # --- 0. Validate inputs and merge default user_options --- 
   # (To be implemented: validate inputs, set up default options for each sub-module if not provided)
   
-  # Placeholder for options - real implementation would merge with defaults
+  # Default options for HRF estimation
   opts_pass0       <- user_options$opts_pass0 %||% list()
-  opts_hrf         <- user_options$opts_hrf %||% list()
+
+  default_opts_hrf <- list(
+    hrf_fir_taps = 12L,
+    hrf_fir_span_seconds = 24,
+    good_voxel_R2_threshold = 0.05,
+    cv_folds = 5L,
+    lambda1_grid = 10^seq(-2, 1, length.out = 5),
+    lambda2_grid = 10^seq(-3, 0, length.out = 5),
+    hrf_min_good_voxels = 50L,
+    return_full_model = FALSE
+  )
+  opts_hrf <- utils::modifyList(default_opts_hrf, user_options$opts_hrf %||% list())
+
   opts_rpca        <- user_options$opts_rpca %||% list()
   opts_spectral    <- user_options$opts_spectral %||% list()
   opts_whitening   <- user_options$opts_whitening %||% list()


### PR DESCRIPTION
## Summary
- set up default HRF options in `ndx_run_sprint1`
- merge user HRF options with defaults using `modifyList`
- expand defaults in `validate_hrf_inputs` and remove missing-field error check

## Testing
- `Rscript run_tests.R` *(fails: command not found)*