### PR TITLE
Strip names from OLS residual output

### DIFF
--- a/R/ndx_utils.R
+++ b/R/ndx_utils.R
@@ -41,8 +41,7 @@ calculate_residuals_ols <- function(Y, X) {
 
   # stats::lm.fit is efficient for multiple response variables (columns in Y)
   fit <- stats::lm.fit(X, Y)
-  res <- fit$residuals
-  dimnames(res) <- NULL
+  res <- unname(fit$residuals)
   return(res)
 }
 


### PR DESCRIPTION
## Summary
- return unnamed matrix from `calculate_residuals_ols`

## Testing
- `Rscript run_tests.R` *(fails: `Rscript` not found)*