### PR TITLE
Fix residual handling and RPCA option

### DIFF
--- a/R/ndx_utils.R
+++ b/R/ndx_utils.R
@@ -41,7 +41,9 @@ calculate_residuals_ols <- function(Y, X) {
 
   # stats::lm.fit is efficient for multiple response variables (columns in Y)
   fit <- stats::lm.fit(X, Y)
-  res <- unname(fit$residuals)
+  res <- fit$residuals
+  # Remove any row or column names to ensure pure numeric matrix
+  dimnames(res) <- NULL
   return(res)
 }
 

--- a/tests/testthat/test-workflow.R
+++ b/tests/testthat/test-workflow.R
@@ -56,7 +56,7 @@ user_options_test <- list(
   opts_rpca = list(
     k_global_target = 2, # Small number of components
     rpca_lambda_auto = FALSE,
-    lambda = 0.1 # Provide a small lambda if auto is FALSE
+    rpca_lambda_fixed = 0.1 # Provide a small lambda if auto is FALSE
   ),
   opts_spectral = list(
     n_sine_candidates = 2, # Small number


### PR DESCRIPTION
## Summary
- ensure `calculate_residuals_ols` strips dimnames from returned residual matrix
- correct RPCA option name in workflow test

## Testing
- `Rscript run_tests.R` *(fails: command not found)*