### PR TITLE
Implement spike mask from RPCA S

### DIFF
--- a/man/NDX_Process_Subject.Rd
+++ b/man/NDX_Process_Subject.Rd
@@ -52,6 +52,7 @@ A list containing key outputs from the workflow, such as:
   - `diagnostics_per_pass`: A list of diagnostic metrics for each pass.
   - `beta_history_per_pass`: A list of beta estimates from each pass.
   - (Other final pass outputs like residuals, AR coeffs, nuisance components, etc.)
+  - `spike_TR_mask`: Logical vector of TRs flagged as spikes from RPCA `S`.
 }
 \description{
 This function orchestrates the core modules of the ND-X pipeline. 

--- a/man/ndx_rpca_temporal_components_multirun.Rd
+++ b/man/ndx_rpca_temporal_components_multirun.Rd
@@ -36,8 +36,11 @@ components to be returned (columns in the output matrix).}
   Options are "concat_svd" or "iterative". Default: "concat_svd".}
 }
 \value{
-A matrix containing the concatenated temporal nuisance components `C_r`
-  (total_timepoints x k_global_target). Returns NULL if errors occur or no components generated.
+A list with elements `C_components` and `spike_TR_mask`. `C_components` is a
+matrix of concatenated temporal nuisance components (total_timepoints x
+k\_global\_target). `spike_TR_mask` is a logical vector flagging TRs with
+non-zero sparse activity. Returns NULL if errors occur or no components
+generated.
 }
 \description{
 This function implements a multi-run RPCA strategy. It performs RPCA on each

--- a/tests/testthat/test-rpca.R
+++ b/tests/testthat/test-rpca.R
@@ -43,13 +43,15 @@ test_that("ndx_rpca_temporal_components_multirun runs (single run, concat_svd)",
       user_options = user_opts
     )
   })
-  
+
   expect_true(!is.null(components), "Components should not be NULL for valid inputs (single run)")
   if (!is.null(components)) {
-    expect_true(is.matrix(components), "Output should be a matrix (single run)")
-    expect_equal(nrow(components), test_data$total_T, info = "Output rows should match total timepoints (single run)")
-    expect_true(ncol(components) <= k_target, info = sprintf("Output columns (%d) should be <= k_target (%d) (single run)", ncol(components), k_target))
-    expect_true(ncol(components) > 0, info = "Output should have >0 components if k_target > 0 (single run)")
+    expect_true(is.list(components))
+    expect_true(is.matrix(components$C_components))
+    expect_equal(nrow(components$C_components), test_data$total_T)
+    expect_true(ncol(components$C_components) <= k_target)
+    expect_length(components$spike_TR_mask, test_data$total_T)
+    expect_type(components$spike_TR_mask, "logical")
   }
 })
 
@@ -76,13 +78,15 @@ test_that("ndx_rpca_temporal_components_multirun runs (multi-run, concat_svd)", 
       user_options = user_opts
     )
   })
-  
+
   expect_true(!is.null(components), "Components should not be NULL for valid inputs (multi-run)")
   if (!is.null(components)) {
-    expect_true(is.matrix(components), "Output should be a matrix (multi-run)")
-    expect_equal(nrow(components), test_data$total_T, info = "Output rows should match total timepoints (multi-run)")
-    expect_true(ncol(components) <= k_target, info = sprintf("Output columns (%d) should be <= k_target (%d) (multi-run)", ncol(components), k_target))
-    expect_true(ncol(components) > 0, info = "Output should have >0 components if k_target > 0 (multi-run)")
+    expect_true(is.list(components))
+    expect_true(is.matrix(components$C_components))
+    expect_equal(nrow(components$C_components), test_data$total_T)
+    expect_true(ncol(components$C_components) <= k_target)
+    expect_length(components$spike_TR_mask, test_data$total_T)
+    expect_type(components$spike_TR_mask, "logical")
   }
 })
 
@@ -111,14 +115,12 @@ test_that("ndx_rpca_temporal_components_multirun runs with iterative merge strat
 
   expect_true(!is.null(components_iter), "Components should not be NULL for iterative merge")
   if (!is.null(components_iter)) {
-    expect_true(is.matrix(components_iter))
-    expect_equal(nrow(components_iter), test_data$total_T,
-                 info = "Output rows should match total timepoints (iterative)")
-    expect_true(ncol(components_iter) <= k_target,
-                info = sprintf("Output columns (%d) should be <= k_target (%d) (iterative)",
-                                ncol(components_iter), k_target))
-    expect_true(ncol(components_iter) > 0,
-                info = "Output should have >0 components if k_target > 0 (iterative)")
+    expect_true(is.list(components_iter))
+    expect_true(is.matrix(components_iter$C_components))
+    expect_equal(nrow(components_iter$C_components), test_data$total_T)
+    expect_true(ncol(components_iter$C_components) <= k_target)
+    expect_length(components_iter$spike_TR_mask, test_data$total_T)
+    expect_type(components_iter$spike_TR_mask, "logical")
 
     # The C_r components (components_iter) are not guaranteed to be orthonormal.
     # V_global (the voxel-space basis) is orthonormal, but C_r = E_r %*% V_global.

--- a/tests/testthat/test-workflow.R
+++ b/tests/testthat/test-workflow.R
@@ -101,7 +101,7 @@ test_that("NDX_Process_Subject runs with minimal valid inputs and returns correc
   expected_names <- c(
     "final_task_betas", "Y_residuals_final_unwhitened", "ar_coeffs_voxelwise",
     "rpca_components", "spectral_sines", "estimated_hrfs", "pass0_vars",
-    "na_mask_whitening", "X_full_design_final", "diagnostics_per_pass",
+    "na_mask_whitening", "spike_TR_mask", "X_full_design_final", "diagnostics_per_pass",
     "beta_history_per_pass", "num_passes_completed"
   )
   expect_named(workflow_output, expected = expected_names, ignore.order = TRUE)
@@ -113,6 +113,9 @@ test_that("NDX_Process_Subject runs with minimal valid inputs and returns correc
   if (!is.null(workflow_output$X_full_design_final)) {
       expect_equal(nrow(workflow_output$X_full_design_final), total_timepoints_test)
   }
+
+  expect_length(workflow_output$spike_TR_mask, total_timepoints_test)
+  expect_type(workflow_output$spike_TR_mask, "logical")
   
   # Check diagnostics_per_pass structure
   expect_true(is.list(workflow_output$diagnostics_per_pass))


### PR DESCRIPTION
## Summary
- compute spike masks from RPCA sparse component
- propagate spike information through workflow
- adapt unit tests for new list return

## Testing
- `Rscript run_tests.R` *(fails: command not found)*