### PR TITLE
Validate spike mask length

### DIFF
--- a/man/ndx_rpca_temporal_components_multirun.Rd
+++ b/man/ndx_rpca_temporal_components_multirun.Rd
@@ -39,8 +39,9 @@ components to be returned (columns in the output matrix).}
 A list with elements `C_components` and `spike_TR_mask`. `C_components` is a
 matrix of concatenated temporal nuisance components (total_timepoints x
 k\_global\_target). `spike_TR_mask` is a logical vector flagging TRs with
-non-zero sparse activity. Returns NULL if errors occur or no components
-generated.
+non-zero sparse activity. The mask length is validated against
+`nrow(Y_residuals_cat)` and padded or truncated with a warning if necessary.
+Returns NULL if errors occur or no components generated.
 }
 \description{
 This function implements a multi-run RPCA strategy. It performs RPCA on each

--- a/tests/testthat/test-spike_mask_validation.R
+++ b/tests/testthat/test-spike_mask_validation.R
@@ -1,0 +1,17 @@
+context("spike mask validation")
+
+# Use internal helper from ndx_rpca.R
+
+
+test_that("finalize_spike_mask warns and fixes length mismatch", {
+  mask_list <- list(run_1 = c(TRUE, FALSE),
+                    run_2 = c(FALSE))
+  unique_runs <- c(1, 2)
+  n_total <- 5
+  expect_warning(
+    mask_final <- .finalize_spike_mask(mask_list, unique_runs, n_total),
+    "spike_TR_mask length"
+  )
+  expect_length(mask_final, n_total)
+  expect_type(mask_final, "logical")
+})


### PR DESCRIPTION
## Summary
- warn and fix length mismatches for spike masks
- document spike mask length validation in Rd file
- add helper `.finalize_spike_mask()` and test for it

## Testing
- `Rscript run_tests.R` *(fails: command not found)*