### PR TITLE
Improve utility functions and extend tests

### DIFF
--- a/R/ndx_utils.R
+++ b/R/ndx_utils.R
@@ -10,6 +10,7 @@
 #' @import matrixStats
 NULL
 
+
 # Placeholder for actual utility functions
 
 #' Calculate OLS residuals using lm.fit
@@ -21,6 +22,17 @@ NULL
 #' @keywords internal
 #' @export
 calculate_residuals_ols <- function(Y, X) {
+  # Convert inputs to numeric matrices if possible
+  if (!is.matrix(Y)) {
+    Y <- as.matrix(Y)
+  }
+  if (!is.matrix(X)) {
+    X <- as.matrix(X)
+  }
+  if (!is.numeric(Y) || !is.numeric(X)) {
+    stop("`Y` and `X` must be numeric matrices.")
+  }
+
   if (nrow(Y) != nrow(X)) {
     stop("Number of rows in Y and X must match for OLS.")
   }
@@ -109,8 +121,15 @@ calculate_DES <- function(current_residuals_unwhitened, VAR_BASELINE_FOR_DES) {
     warning("calculate_DES: Inputs cannot be NULL.")
     return(NA_real_)
   }
-  if (!is.numeric(current_residuals_unwhitened) || !is.numeric(VAR_BASELINE_FOR_DES)) {
-    warning("calculate_DES: Inputs must be numeric.")
+  if (!is.numeric(current_residuals_unwhitened)) {
+    current_residuals_unwhitened <- as.numeric(current_residuals_unwhitened)
+    if (anyNA(current_residuals_unwhitened)) {
+      warning("calculate_DES: `current_residuals_unwhitened` contains non-numeric values.")
+      return(NA_real_)
+    }
+  }
+  if (!is.numeric(VAR_BASELINE_FOR_DES)) {
+    warning("calculate_DES: `VAR_BASELINE_FOR_DES` must be numeric.")
     return(NA_real_)
   }
   if (length(VAR_BASELINE_FOR_DES) != 1 || !is.finite(VAR_BASELINE_FOR_DES)){
@@ -186,14 +205,20 @@ ndx_orthogonalize_matrix_against_basis <- function(target_matrix, basis_matrix, 
   if (is.null(target_matrix) || ncol(target_matrix) == 0) {
     return(target_matrix)
   }
-  if (!is.matrix(target_matrix) || !is.numeric(target_matrix)){
+  if (!is.matrix(target_matrix)) {
+    target_matrix <- as.matrix(target_matrix)
+  }
+  if (!is.numeric(target_matrix)) {
     stop("`target_matrix` must be a numeric matrix.")
   }
 
   if (is.null(basis_matrix) || ncol(basis_matrix) == 0) {
     return(target_matrix)
   }
-  if (!is.matrix(basis_matrix) || !is.numeric(basis_matrix)){
+  if (!is.matrix(basis_matrix)) {
+    basis_matrix <- as.matrix(basis_matrix)
+  }
+  if (!is.numeric(basis_matrix)) {
     stop("`basis_matrix` must be a numeric matrix.")
   }
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -206,3 +206,33 @@ test_that("calculate_R2_voxelwise handles all-NA columns and extra NA residuals"
   expect_equal(r2_vals[1], expected_r2_col1, tolerance = 1e-9)
   expect_equal(r2_vals[2], 0)
 })
+
+test_that("calculate_DES computes expected score and handles edge cases", {
+  set.seed(123)
+  baseline_res <- rnorm(100, sd = 2)
+  var_baseline <- var(baseline_res)
+  current_res <- rnorm(100, sd = 1)
+
+  expected <- 1 - var(current_res) / var_baseline
+  expect_equal(calculate_DES(current_res, var_baseline), expected, tolerance = 1e-8)
+
+  expect_true(is.na(calculate_DES(current_res, 0)))
+  expect_true(is.na(calculate_DES(current_res, NA_real_)))
+})
+
+test_that("ndx_orthogonalize_matrix_against_basis orthogonalizes correctly", {
+  set.seed(42)
+  basis <- matrix(rnorm(40), 10, 4)
+  target <- matrix(rnorm(30), 10, 3)
+  ortho <- ndx_orthogonalize_matrix_against_basis(target, basis)
+
+  expect_equal(dim(ortho), dim(target))
+  cross_val <- t(ortho) %*% basis
+  expect_true(all(abs(cross_val) < 1e-8))
+})
+
+test_that("ndx_orthogonalize_matrix_against_basis handles empty basis", {
+  target <- matrix(rnorm(12), 4, 3)
+  expect_equal(ndx_orthogonalize_matrix_against_basis(target, NULL), target)
+  expect_equal(ndx_orthogonalize_matrix_against_basis(target, matrix(numeric(0), nrow = 4)), target)
+})


### PR DESCRIPTION
## Summary
- add input checks and conversions in `calculate_residuals_ols`
- strengthen validation in `calculate_DES`
- make `ndx_orthogonalize_matrix_against_basis` accept any matrix-like input
- add unit tests for DES and orthogonalization functions

## Testing
- `R` not installed, unable to run `run_tests.R`