### PR TITLE
Implement basic auto-adaptive HRF clustering

### DIFF
--- a/R/ndx_options.R
+++ b/R/ndx_options.R
@@ -31,6 +31,8 @@
 #'   \item{`return_full_model`}{Logical, whether to return full model. Default: FALSE}
 #'   \item{`hrf_cluster_method`}{Character, clustering method. Default: "none"}
 #'   \item{`num_hrf_clusters`}{Integer, number of HRF clusters. Default: 1}
+#'   \item{`hrf_cluster_merge_corr_thresh`}{Numeric, correlation threshold for merging clusters. Default: 0.95}
+#'   \item{`hrf_cluster_min_size`}{Integer, minimum voxels per cluster before reassignment. Default: 5}
 #'   \item{`hrf_min_events_for_fir`}{Integer, minimum events for FIR. Default: 6}
 #'   \item{`hrf_low_event_threshold`}{Integer, low event threshold. Default: 12}
 #'   \item{`hrf_target_event_count_for_lambda_scaling`}{Integer, target event count. Default: 20}

--- a/R/ndx_workflow.R
+++ b/R/ndx_workflow.R
@@ -73,6 +73,8 @@ NDX_Process_Subject <- function(Y_fmri,
     return_full_model = FALSE,
     hrf_cluster_method = "none", # Default to no clustering
     num_hrf_clusters = 1L,       # Consistent with no clustering
+    hrf_cluster_merge_corr_thresh = 0.95,
+    hrf_cluster_min_size = 5L,
     # Options for sparse event handling in HRF estimation (NDX-12)
     hrf_min_events_for_fir = 6L, 
     hrf_low_event_threshold = 12L,


### PR DESCRIPTION
## Summary
- add clustering merge threshold and min-size options
- validate new HRF options
- implement `.auto_adapt_hrf_clusters` for merging and reassigning clusters
- call the new logic when estimating HRFs

## Testing
- `Rscript` not found; `run_tests.R` could not be executed