### PR TITLE
Add iterative workflow tests

### DIFF
--- a/tests/testthat/test-workflow_iterative.R
+++ b/tests/testthat/test-workflow_iterative.R
@@ -1,0 +1,132 @@
+context("NDX_Process_Subject - Iterative Workflow")
+
+# Test 1: multiple passes and adaptive diagnostics
+
+test_that("Workflow runs multiple passes and adapts", {
+  set.seed(123)
+  TR_test <- 2.0
+  n_time <- 40
+  n_runs <- 1
+  total_T <- n_time * n_runs
+  n_vox <- 5
+
+  Y_fmri <- matrix(rnorm(total_T * n_vox), nrow = total_T, ncol = n_vox)
+  run_idx <- rep(1:n_runs, each = n_time)
+  motion_params <- matrix(rnorm(total_T * 3), nrow = total_T, ncol = 3)
+  colnames(motion_params) <- paste0("mot", 1:3)
+
+  events <- data.frame(
+    onsets = c(10, 30) * TR_test,
+    durations = c(5, 5) * TR_test,
+    condition = factor(c("TaskA", "TaskB")),
+    blockids = 1
+  )
+
+  user_opts <- list(
+    opts_pass0 = list(poly_degree = 1),
+    opts_hrf = list(
+      hrf_fir_taps = 6,
+      hrf_fir_span_seconds = 12,
+      good_voxel_R2_threshold = -Inf,
+      lambda1_grid = c(0.1),
+      lambda2_grid = c(0.1),
+      cv_folds = 2,
+      hrf_min_good_voxels = 1,
+      hrf_cluster_method = "none",
+      num_hrf_clusters = 1
+    ),
+    opts_rpca = list(
+      k_global_target = 2,
+      rpca_lambda_auto = FALSE,
+      rpca_lambda_fixed = 0.1,
+      rpca_merge_strategy = "concat_svd",
+      k_rpca_min = 2,
+      k_rpca_max = 10
+    ),
+    opts_spectral = list(n_sine_candidates = 2, nyquist_guard_factor = 0.1),
+    opts_whitening = list(global_ar_on_design = FALSE, max_ar_failures_prop = 0.5),
+    opts_ridge = list(lambda_ridge = 0.5),
+    max_passes = 3,
+    min_des_gain_convergence = -Inf,
+    min_rho_noise_projection_convergence = -Inf
+  )
+
+  res <- NDX_Process_Subject(
+    Y_fmri = Y_fmri,
+    events = events,
+    motion_params = motion_params,
+    run_idx = run_idx,
+    TR = TR_test,
+    user_options = user_opts,
+    verbose = FALSE
+  )
+
+  expect_gte(res$num_passes_completed, 2)
+  expect_length(res$diagnostics_per_pass, res$num_passes_completed)
+  k1 <- res$diagnostics_per_pass[[1]]$k_rpca_global
+  k2 <- res$diagnostics_per_pass[[2]]$k_rpca_global
+  expect_true(is.numeric(k1) && is.numeric(k2))
+  expect_true(k1 != k2)
+})
+
+# Test 2: convergence stops early with strict thresholds
+
+test_that("Convergence thresholds cause early stop", {
+  set.seed(456)
+  TR_test <- 2.0
+  n_time <- 40
+  n_runs <- 1
+  total_T <- n_time * n_runs
+  n_vox <- 5
+
+  Y_fmri <- matrix(rnorm(total_T * n_vox), nrow = total_T, ncol = n_vox)
+  run_idx <- rep(1:n_runs, each = n_time)
+  motion_params <- matrix(rnorm(total_T * 3), nrow = total_T, ncol = 3)
+  colnames(motion_params) <- paste0("mot", 1:3)
+
+  events <- data.frame(
+    onsets = c(10, 30) * TR_test,
+    durations = c(5, 5) * TR_test,
+    condition = factor(c("TaskA", "TaskB")),
+    blockids = 1
+  )
+
+  user_opts <- list(
+    opts_pass0 = list(poly_degree = 1),
+    opts_hrf = list(
+      hrf_fir_taps = 6,
+      hrf_fir_span_seconds = 12,
+      good_voxel_R2_threshold = -Inf,
+      lambda1_grid = c(0.1),
+      lambda2_grid = c(0.1),
+      cv_folds = 2,
+      hrf_min_good_voxels = 1,
+      hrf_cluster_method = "none",
+      num_hrf_clusters = 1
+    ),
+    opts_rpca = list(
+      k_global_target = 2,
+      rpca_lambda_auto = FALSE,
+      rpca_lambda_fixed = 0.1,
+      rpca_merge_strategy = "concat_svd"
+    ),
+    opts_spectral = list(n_sine_candidates = 2, nyquist_guard_factor = 0.1),
+    opts_whitening = list(global_ar_on_design = FALSE, max_ar_failures_prop = 0.5),
+    opts_ridge = list(lambda_ridge = 0.5),
+    max_passes = 3,
+    min_des_gain_convergence = 1,
+    min_rho_noise_projection_convergence = 2
+  )
+
+  res <- NDX_Process_Subject(
+    Y_fmri = Y_fmri,
+    events = events,
+    motion_params = motion_params,
+    run_idx = run_idx,
+    TR = TR_test,
+    user_options = user_opts,
+    verbose = FALSE
+  )
+
+  expect_lt(res$num_passes_completed, user_opts$max_passes)
+})


### PR DESCRIPTION
## Summary
- add tests for iterative NDX workflow behaviour
- ensure multiple passes run when convergence thresholds are loose
- ensure convergence stops early for strict thresholds

## Testing
- `Rscript run_tests.R` *(fails: command not found)*