### PR TITLE
Fix ridge GCV test helper

### DIFF
--- a/tests/testthat/helper-ridge_data.R
+++ b/tests/testthat/helper-ridge_data.R
@@ -1,0 +1,49 @@
+# Helper functions for ridge regression tests
+
+# Generates simulated ridge regression data with optional NA periods.
+# Returns a list containing Y, X, true_betas, and na_mask.
+.create_ridge_test_data <- function(n_timepoints, n_regressors, n_voxels,
+                                    true_betas, noise_sd = 1.0, na_head = 0) {
+  set.seed(123)  # Ensure reproducibility across tests
+  X <- matrix(rnorm(n_timepoints * n_regressors), n_timepoints, n_regressors)
+
+  if (n_regressors > 0) X[, 1] <- 1
+  if (n_regressors > 1) X[, 2] <- seq(0, 1, length.out = n_timepoints)
+  if (n_regressors > 2) X[, 3] <- (seq(0, 1, length.out = n_timepoints))^2
+  if (n_regressors > 3) X[, 4] <- sin(seq(0, 2 * pi, length.out = n_timepoints))
+
+  if (n_regressors > 0) {
+    if (is.vector(true_betas)) {
+      if (length(true_betas) != n_regressors)
+        stop("Length of true_betas vector must match n_regressors")
+      true_betas_matrix <- matrix(rep(true_betas, n_voxels),
+                                  nrow = n_regressors, ncol = n_voxels)
+    } else if (is.matrix(true_betas)) {
+      if (nrow(true_betas) != n_regressors || ncol(true_betas) != n_voxels)
+        stop("Dimensions of true_betas matrix are incorrect.")
+      true_betas_matrix <- true_betas
+    } else {
+      stop("true_betas must be a vector or a matrix.")
+    }
+    Y_signal <- X %*% true_betas_matrix
+  } else {
+    true_betas_matrix <- matrix(0, nrow = 0, ncol = n_voxels)
+    Y_signal <- matrix(0, nrow = n_timepoints, ncol = n_voxels)
+  }
+
+  Y_noise <- matrix(rnorm(n_timepoints * n_voxels, sd = noise_sd),
+                    n_timepoints, n_voxels)
+  Y <- Y_signal + Y_noise
+
+  na_mask_vec <- rep(FALSE, n_timepoints)
+  if (na_head > 0 && n_timepoints > na_head) {
+    Y[1:na_head, ] <- NA
+    na_mask_vec[1:na_head] <- TRUE
+  }
+
+  if (n_regressors > 0) colnames(X) <- paste0("Reg", 1:n_regressors)
+  if (n_voxels > 0) colnames(Y) <- paste0("Voxel", 1:n_voxels)
+
+  list(Y = Y, X = X, true_betas = true_betas_matrix, na_mask = na_mask_vec)
+}
+

--- a/tests/testthat/test-ridge.R
+++ b/tests/testthat/test-ridge.R
@@ -1,47 +1,6 @@
 context("ndx_solve_anisotropic_ridge - Functionality")
+# Using .create_ridge_test_data from helper-ridge_data.R
 
-# Helper function to create simple test data
-.create_ridge_test_data <- function(n_timepoints, n_regressors, n_voxels, true_betas, noise_sd = 1.0, na_head = 0) {
-  set.seed(123) # Ensure reproducibility for this helper
-  X <- matrix(rnorm(n_timepoints * n_regressors), n_timepoints, n_regressors)
-  # Ensure X has some variance and is not perfectly collinear for basic tests
-  if (n_regressors > 0) X[,1] <- 1 # Intercept if at least one regressor
-  if (n_regressors > 1) X[,2] <- seq(0,1,length.out=n_timepoints)
-  if (n_regressors > 2) X[,3] <- (seq(0,1,length.out=n_timepoints))^2
-  if (n_regressors > 3) X[,4] <- sin(seq(0,2*pi,length.out=n_timepoints))
-  
-  # Ensure true_betas is a matrix of correct dimensions (n_regressors x n_voxels)
-  if (n_regressors > 0) {
-    if (is.vector(true_betas)) {
-      if (length(true_betas) != n_regressors) stop("Length of true_betas vector must match n_regressors")
-      true_betas_matrix <- matrix(rep(true_betas, n_voxels), nrow = n_regressors, ncol = n_voxels)
-    } else if (is.matrix(true_betas)) {
-      if (nrow(true_betas) != n_regressors || ncol(true_betas) != n_voxels) {
-        stop("Dimensions of true_betas matrix are incorrect.")
-      }
-      true_betas_matrix <- true_betas
-    } else {
-      stop("true_betas must be a vector or a matrix.")
-    }
-    Y_signal <- X %*% true_betas_matrix
-  } else { # No regressors
-      true_betas_matrix <- matrix(0, nrow=0, ncol=n_voxels)
-      Y_signal <- matrix(0, nrow=n_timepoints, ncol=n_voxels)
-  }
-
-  Y_noise <- matrix(rnorm(n_timepoints * n_voxels, sd = noise_sd), n_timepoints, n_voxels)
-  Y <- Y_signal + Y_noise
-  
-  na_mask_vec <- rep(FALSE, n_timepoints)
-  if (na_head > 0 && n_timepoints > na_head) {
-    Y[1:na_head, ] <- NA
-    na_mask_vec[1:na_head] <- TRUE
-  }
-  
-  if (n_regressors > 0) colnames(X) <- paste0("Reg", 1:n_regressors)
-  if (n_voxels > 0) colnames(Y) <- paste0("Voxel", 1:n_voxels)
-  return(list(Y = Y, X = X, true_betas = true_betas_matrix, na_mask = na_mask_vec))
-}
 
 test_that("ndx_solve_anisotropic_ridge computes correct betas for a simple case", {
   set.seed(123)


### PR DESCRIPTION
## Summary
- move `.create_ridge_test_data` to a new helper so all tests can use it
- clean up test file accordingly

## Testing
- `Rscript run_tests.R` *(fails: `Rscript` not found)*