### PR TITLE
Fix gcv tuning with no noise subspace

### DIFF
--- a/R/ndx_ridge.R
+++ b/R/ndx_ridge.R
@@ -49,11 +49,17 @@ ndx_gcv_tune_lambda_parallel <- function(Y_whitened, X_whitened, P_Noise,
                                          lambda_ratio = 0.05) {
   n <- nrow(X_whitened)
   I_reg <- diag(1, ncol(X_whitened))
-  P_Signal <- I_reg - P_Noise
+  if (is.null(P_Noise)) {
+    diag_noise <- rep(0, ncol(X_whitened))
+    P_Signal <- I_reg
+  } else {
+    diag_noise <- diag(P_Noise)
+    P_Signal <- I_reg - P_Noise
+  }
   best_lambda <- lambda_grid[1]
   best_gcv <- Inf
   for (lam in lambda_grid) {
-    K_diag <- lam * diag(P_Noise) + (lam * lambda_ratio) * diag(P_Signal)
+    K_diag <- lam * diag_noise + (lam * lambda_ratio) * diag(P_Signal)
     XtX <- crossprod(X_whitened)
     XtX_pen <- XtX
     diag(XtX_pen) <- diag(XtX_pen) + pmax(K_diag, .Machine$double.eps)

--- a/man/ndx_gcv_tune_lambda_parallel.Rd
+++ b/man/ndx_gcv_tune_lambda_parallel.Rd
@@ -10,7 +10,8 @@ ndx_gcv_tune_lambda_parallel(Y_whitened, X_whitened, P_Noise,
 \arguments{
 \item{Y_whitened}{Whitened responses.}
 \item{X_whitened}{Whitened design.}
-\item{P_Noise}{Noise projection matrix.}
+\item{P_Noise}{Noise projection matrix. May be \code{NULL} if no noise
+  subspace is supplied.}
 \item{lambda_grid}{Candidate lambda values.}
 \item{lambda_ratio}{Multiplier for perpendicular lambda.}
 }

--- a/tests/testthat/test-ridge_gcv.R
+++ b/tests/testthat/test-ridge_gcv.R
@@ -17,3 +17,11 @@ test_that("ndx_solve_anisotropic_ridge performs GCV tuning", {
     res_var_scale = res_var)
   expect_equal(dim(betas), c(2,1))
 })
+
+test_that("ndx_gcv_tune_lambda_parallel handles NULL P_Noise", {
+  data <- .create_ridge_test_data(30, 2, 1, c(1, -1), noise_sd = 0.2)
+  lam <- ndx_gcv_tune_lambda_parallel(data$Y, data$X, NULL,
+                                      lambda_grid = c(0.1, 1), lambda_ratio = 0.1)
+  expect_true(is.numeric(lam) && length(lam) == 1)
+  expect_true(lam %in% c(0.1, 1))
+})


### PR DESCRIPTION
## Summary
- handle `NULL` noise projector in `ndx_gcv_tune_lambda_parallel`
- document that `P_Noise` can be `NULL`
- add unit test covering the `NULL` case

## Testing
- `Rscript run_tests.R` *(fails: command not found)*