### PR TITLE
Fix baseline_model call and S-matrix weights

### DIFF
--- a/R/ndx_gdlite.R
+++ b/R/ndx_gdlite.R
@@ -778,7 +778,13 @@ ndx_run_gdlite <- function(Y_fmri,
   
   # Baseline model (polynomials per run, and run-specific intercepts if poly_degree allows)
   # fmrireg::baseline_model with basis="poly" and degree=poly_degree handles run intercepts correctly.
-  baseline_des <- fmrireg::baseline_model(sframe = sf, basis = "poly", degree = poly_degree, nuisance_list = list())
+  # No nuisance regressors are included at this stage, so rely on the
+  # default `nuisance_list = NULL` behavior. Passing an empty list would
+  # cause an error inside `fmrireg::baseline_model` because it expects the
+  # list length and row counts to match the sampling frame.
+  baseline_des <- fmrireg::baseline_model(sframe = sf,
+                                          basis = "poly",
+                                          degree = poly_degree)
   X_poly_intercepts <- fmrireg::design_matrix(baseline_des)
   if (is.null(X_poly_intercepts)) X_poly_intercepts <- matrix(1, nrow=n_timepoints, ncol=1)
 

--- a/R/ndx_workflow.R
+++ b/R/ndx_workflow.R
@@ -310,8 +310,18 @@ NDX_Process_Subject <- function(Y_fmri,
       }
       current_pass_results$S_matrix_rpca <- rpca_out$S_matrix_cat # Store S matrix
       current_pass_results$V_global_singular_values_from_rpca <- rpca_out$V_global_singular_values # Store for next pass
-      current_pass_results$precision_weights <- ndx_precision_weights_from_S(rpca_out$S_matrix_cat)
-      precision_weights_for_pass <- current_pass_results$precision_weights
+
+      if (!is.null(rpca_out$S_matrix_cat) &&
+          is.matrix(rpca_out$S_matrix_cat) &&
+          is.numeric(rpca_out$S_matrix_cat)) {
+        current_pass_results$precision_weights <-
+          ndx_precision_weights_from_S(rpca_out$S_matrix_cat)
+        precision_weights_for_pass <- current_pass_results$precision_weights
+      } else {
+        if (verbose) message("    RPCA did not return a valid numeric S matrix; skipping precision weighting for this pass.")
+        current_pass_results$precision_weights <- NULL
+        precision_weights_for_pass <- NULL
+      }
     } else {
       if (verbose && !is.null(rpca_out)) {
           message("    Warning: rpca_out from ndx_rpca_temporal_components_multirun was not NULL but not a list as expected.")


### PR DESCRIPTION
## Summary
- avoid passing an empty list to `baseline_model`
- guard precision-weight calculation when RPCA S matrix is missing

## Testing
- `Rscript run_tests.R` *(fails: command not found)*