### PR TITLE
Fix projection matrices and numeric design handling

### DIFF
--- a/R/ndx_gdlite.R
+++ b/R/ndx_gdlite.R
@@ -797,6 +797,8 @@ ndx_run_gdlite <- function(Y_fmri,
     }
   }
   X_gd <- do.call(cbind, X_gd_parts)
+  X_gd <- as.matrix(X_gd)
+  storage.mode(X_gd) <- "numeric"
   if (any(duplicated(colnames(X_gd)))) {
       colnames(X_gd) <- make.names(colnames(X_gd), unique=TRUE)
   }

--- a/R/ndx_workflow.R
+++ b/R/ndx_workflow.R
@@ -484,22 +484,24 @@ NDX_Process_Subject <- function(Y_fmri,
           noise_rpca_unique_col_indices <- which(is_rpca_unique_col)
           noise_spectral_unique_col_indices <- which(is_spectral_unique_col)
 
+          I_reg <- diag(1, n_regressors)
+
           U_noise <- NULL
           if (length(noise_rpca_col_indices) > 0)
-            U_noise <- cbind(U_noise, current_pass_results$X_whitened[, noise_rpca_col_indices, drop = FALSE])
+            U_noise <- cbind(U_noise, I_reg[, noise_rpca_col_indices, drop = FALSE])
           if (length(noise_spectral_col_indices) > 0)
-            U_noise <- cbind(U_noise, current_pass_results$X_whitened[, noise_spectral_col_indices, drop = FALSE])
+            U_noise <- cbind(U_noise, I_reg[, noise_spectral_col_indices, drop = FALSE])
 
           U_gd <- NULL
           if (opts_annihilation$annihilation_enable_mode && length(noise_gdlite_col_indices) > 0)
-            U_gd <- current_pass_results$X_whitened[, noise_gdlite_col_indices, drop = FALSE]
+            U_gd <- I_reg[, noise_gdlite_col_indices, drop = FALSE]
 
           U_unique <- NULL
           if (opts_annihilation$annihilation_enable_mode) {
             if (length(noise_rpca_unique_col_indices) > 0)
-              U_unique <- cbind(U_unique, current_pass_results$X_whitened[, noise_rpca_unique_col_indices, drop = FALSE])
+              U_unique <- cbind(U_unique, I_reg[, noise_rpca_unique_col_indices, drop = FALSE])
             if (length(noise_spectral_unique_col_indices) > 0)
-              U_unique <- cbind(U_unique, current_pass_results$X_whitened[, noise_spectral_unique_col_indices, drop = FALSE])
+              U_unique <- cbind(U_unique, I_reg[, noise_spectral_unique_col_indices, drop = FALSE])
           }
 
           proj_mats <- ndx_compute_projection_matrices(U_GD = U_gd, U_Unique = U_unique,


### PR DESCRIPTION
## Summary
- ensure anisotropic ridge uses canonical basis when forming projection matrices
- coerce GLMdenoise-Lite design matrix to numeric

## Testing
- `R CMD build --no-build-vignettes --no-manual`
- `R CMD check fmridenoise_*.tar.gz`