### PR TITLE
Improve precision weights robustness

### DIFF
--- a/R/ndx_precision_weights.R
+++ b/R/ndx_precision_weights.R
@@ -6,17 +6,32 @@
 #'
 #' @param S_matrix Numeric matrix of RPCA sparse components (timepoints x voxels).
 #' @param mad_floor Numeric minimum value for the MAD scaling. Default 1e-6.
+#' @param na_zero Logical; if `TRUE`, any `NA` or infinite values in
+#'   `S_matrix` are treated as zero (yielding a weight of one). Default `TRUE`.
 #' @return Numeric matrix of precision weights with the same dimensions as
 #'   `S_matrix`.
 #' @export ndx_precision_weights_from_S
-ndx_precision_weights_from_S <- function(S_matrix, mad_floor = 1e-6) {
+ndx_precision_weights_from_S <- function(S_matrix, mad_floor = 1e-6,
+                                         na_zero = TRUE) {
   if (!is.matrix(S_matrix) || !is.numeric(S_matrix)) {
     stop("S_matrix must be a numeric matrix.")
   }
   if (!is.numeric(mad_floor) || length(mad_floor) != 1 || mad_floor <= 0) {
     stop("mad_floor must be a positive numeric scalar.")
   }
+  if (!is.logical(na_zero) || length(na_zero) != 1) {
+    stop("na_zero must be a single logical value.")
+  }
 
-  mad_S <- max(stats::mad(abs(S_matrix), na.rm = TRUE), mad_floor)
-  1 / (abs(S_matrix) / mad_S + 1)^2
+  abs_S <- abs(S_matrix)
+  if (na_zero) {
+    abs_S[!is.finite(abs_S)] <- 0
+  }
+
+  mad_S <- max(stats::mad(abs_S, na.rm = TRUE), mad_floor)
+  weights <- 1 / (abs_S / mad_S + 1)^2
+  if (na_zero) {
+    weights[!is.finite(weights)] <- 1
+  }
+  weights
 }

--- a/tests/testthat/test-precision_weights.R
+++ b/tests/testthat/test-precision_weights.R
@@ -8,3 +8,15 @@ test_that("precision weights computed correctly", {
   expect_equal(w, expected)
   expect_equal(dim(w), dim(S))
 })
+
+test_that("NA and Inf values yield weight of one", {
+  S <- matrix(c(1, NA, Inf, -2), nrow = 2)
+  w <- ndx_precision_weights_from_S(S, mad_floor = 1e-6, na_zero = TRUE)
+  abs_S <- abs(S)
+  abs_S[!is.finite(abs_S)] <- 0
+  mad_S <- max(mad(abs_S, na.rm = TRUE), 1e-6)
+  expected <- 1 / (abs_S / mad_S + 1)^2
+  expected[!is.finite(expected)] <- 1
+  expect_equal(w, expected)
+  expect_true(all(is.finite(w)))
+})


### PR DESCRIPTION
## Summary
- handle NA/Inf in `ndx_precision_weights_from_S`
- avoid recomputing `abs` for MAD and weight calculation
- add unit test covering NA/Inf input

## Testing
- `Rscript run_tests.R` *(fails: command not found)*