### PR TITLE
Add finite-value check in ndx_spectral_sines

### DIFF
--- a/R/ndx_spectral.R
+++ b/R/ndx_spectral.R
@@ -25,8 +25,9 @@
 #' @return A matrix with `2 * n_selected_peaks` columns and `length(mean_residual_for_spectrum)`
 #'   rows. Each pair of columns represents sine and cosine regressors for an
 #'   identified peak frequency. The attribute "freq" contains the frequencies
-#'   (in Hz) of the selected peaks. Returns NULL if no peaks are found or if
-#'   input is unsuitable.
+#'   (in Hz) of the selected peaks. Returns NULL if no peaks are found.
+#'   Returns a 0-column matrix if the spectral step is aborted due to invalid
+#'   parameters or non-finite input.
 #'
 #' @examples
 #' \dontrun{
@@ -68,6 +69,11 @@ ndx_spectral_sines <- function(mean_residual_for_spectrum, TR,
   if (!is.numeric(TR) || TR <= 0) {
     warning("TR must be a positive numeric value.")
     return(NULL)
+  }
+
+  if (!all(is.finite(mean_residual_for_spectrum))) {
+    warning("mean_residual_for_spectrum contains non-finite values.")
+    return(.empty_spec_matrix(length(mean_residual_for_spectrum)))
   }
 
   # De-mean the series (Feedback 2.1)

--- a/tests/testthat/test-spectral.R
+++ b/tests/testthat/test-spectral.R
@@ -103,6 +103,14 @@ test_that("ndx_spectral_sines handles invalid inputs", {
   expect_null(suppressWarnings(ndx_spectral_sines(rnorm(100), TR = -1)))
 })
 
+test_that("ndx_spectral_sines warns and returns empty matrix for non-finite input", {
+  vec_nf <- c(rnorm(10), NA, Inf)
+  expect_warning(res_nf <- ndx_spectral_sines(vec_nf, TR = 1),
+                 "non-finite")
+  expect_true(is.matrix(res_nf) && ncol(res_nf) == 0 && nrow(res_nf) == length(vec_nf))
+  expect_true(length(attr(res_nf, "freq_hz")) == 0)
+})
+
 test_that("nyquist_guard_factor works as expected", {
   set.seed(789)
   TR_val <- 1.0


### PR DESCRIPTION
## Summary
- validate that `mean_residual_for_spectrum` only contains finite values
- warn and return an empty matrix when non‑finite values are supplied
- document empty-matrix returns in the spectral sine helper
- test non‑finite value handling

## Testing
- `Rscript run_tests.R` *(fails: Rscript not found)*