### PR TITLE
Improve weights validation for AR(2) whitening

### DIFF
--- a/R/ndx_whitening.R
+++ b/R/ndx_whitening.R
@@ -81,6 +81,9 @@ ndx_ar2_whitening <- function(Y_data, X_design_full, Y_residuals_for_AR_fit,
         nrow(weights) != n_timepoints || ncol(weights) != n_voxels) {
       stop("weights must be a numeric matrix with dimensions matching Y_data")
     }
+    if (any(!is.finite(weights)) || any(weights < 0)) {
+      stop("weights must contain finite, non-negative numbers")
+    }
   }
 
   AR_coeffs_voxelwise <- matrix(NA_real_, nrow = n_voxels, ncol = order)

--- a/tests/testthat/test-whitening.R
+++ b/tests/testthat/test-whitening.R
@@ -186,8 +186,17 @@ test_that("Input validation for ndx_ar2_whitening", {
     Y_too_short <- matrix(rnorm(2*2), 2, 2)
     X_too_short <- matrix(rnorm(2*3), 2, 3)
     Y_res_too_short <- matrix(rnorm(2*2), 2, 2)
-    expect_error(ndx_ar2_whitening(Y_too_short, X_too_short, Y_res_too_short, order = 2L), 
+    expect_error(ndx_ar2_whitening(Y_too_short, X_too_short, Y_res_too_short, order = 2L),
                  regexp = "Number of timepoints \\(2\\) must be greater than AR order \\(2\\)\\.")
+
+    weights_neg <- matrix(-1, nrow = 100, ncol = 2)
+    expect_error(ndx_ar2_whitening(Y_good, X_good, Y_res_good, weights = weights_neg),
+                 "weights must contain finite, non-negative numbers")
+
+    weights_inf <- matrix(1, nrow = 100, ncol = 2)
+    weights_inf[1,1] <- Inf
+    expect_error(ndx_ar2_whitening(Y_good, X_good, Y_res_good, weights = weights_inf),
+                 "weights must contain finite, non-negative numbers")
 }) 
 
 test_that("ndx_ar2_whitening effectively whitens AR(2) noise", {


### PR DESCRIPTION
## Summary
- enforce finite and non-negative values in `ndx_ar2_whitening` weights
- test validation errors for invalid weights

## Testing
- `Rscript run_tests.R` *(fails: command not found)*