### PR TITLE
Implement max_ar_failures_prop check

### DIFF
--- a/R/ndx_options.R
+++ b/R/ndx_options.R
@@ -66,7 +66,7 @@
 #' \describe{
 #'   \item{`order`}{Integer, AR order. Default: 2}
 #'   \item{`global_ar_on_design`}{Logical, apply global AR on design. Default: TRUE}
-#'   \item{`max_ar_failures_prop`}{Numeric, maximum proportion of AR failures. Default: 0.1}
+#'   \item{`max_ar_failures_prop`}{Numeric, maximum proportion of AR failures. Default: 0.3}
 #' }
 #'
 #' @section Ridge Options:

--- a/R/ndx_whitening.R
+++ b/R/ndx_whitening.R
@@ -18,6 +18,9 @@
 #' @param weights Optional numeric matrix of weights (timepoints x voxels) used
 #'   for weighted AR coefficient estimation. If NULL, unweighted estimation is
 #'   performed.
+#' @param max_ar_failures_prop Numeric between 0 and 1. If the proportion of
+#'   voxels with failed or unstable AR fits exceeds this threshold, whitening is
+#'   skipped and a warning is issued. Default: 0.3.
 #'
 #' @return A list containing:
 #'   - `Y_whitened`: The AR(order)-whitened fMRI data (timepoints x voxels).
@@ -47,7 +50,8 @@
 #' @export
 ndx_ar2_whitening <- function(Y_data, X_design_full, Y_residuals_for_AR_fit,
                               order = 2L, global_ar_on_design = TRUE,
-                              verbose = TRUE, weights = NULL) {
+                              verbose = TRUE, weights = NULL,
+                              max_ar_failures_prop = 0.3) {
 
   if (!is.matrix(Y_data) || !is.numeric(Y_data)) {
     stop("Y_data must be a numeric matrix.")
@@ -155,8 +159,19 @@ ndx_ar2_whitening <- function(Y_data, X_design_full, Y_residuals_for_AR_fit,
       message(sprintf("%d/%d voxels had AR coefficients set to zero (due to fit failure or instability). These will not be whitened.", num_phi_zeroed, n_voxels))
   }
   
-  if (n_voxels > 0 && (num_phi_zeroed / n_voxels) > 0.3) {
-      warning(sprintf("More than 30%% (%d/%d) of voxels had AR coefficients set to zero. Consider checking input Y_residuals_for_AR_fit.", num_phi_zeroed, n_voxels))
+  failure_prop <- if (n_voxels > 0) num_phi_zeroed / n_voxels else 0
+  if (failure_prop > max_ar_failures_prop) {
+      warning(sprintf(
+        "Proportion of failed AR fits (%.2f) exceeds max_ar_failures_prop %.2f. Skipping whitening.",
+        failure_prop, max_ar_failures_prop))
+      return(list(
+        Y_whitened = Y_data,
+        X_whitened = X_design_full,
+        AR_coeffs_voxelwise = AR_coeffs_voxelwise,
+        AR_coeffs_global = NULL,
+        var_innovations_voxelwise = var_innovations_voxelwise,
+        na_mask = rep(FALSE, n_timepoints)
+      ))
   }
 
   if (verbose) message("Applying voxel-specific AR filter to Y_data...")

--- a/R/ndx_workflow.R
+++ b/R/ndx_workflow.R
@@ -449,7 +449,8 @@ NDX_Process_Subject <- function(Y_fmri,
         Y_residuals_for_AR_fit = temp_glm_for_ar_residuals,
         order = opts_whitening$order %||% 2L,
         global_ar_on_design = opts_whitening$global_ar_on_design %||% TRUE,
-        weights = precision_weights_for_pass
+        weights = precision_weights_for_pass,
+        max_ar_failures_prop = opts_whitening$max_ar_failures_prop %||% 0.3
       )
       current_pass_results$Y_whitened <- whitening_output$Y_whitened
       current_pass_results$X_whitened <- whitening_output$X_whitened

--- a/man/ndx_ar2_whitening.Rd
+++ b/man/ndx_ar2_whitening.Rd
@@ -9,7 +9,8 @@ ndx_ar2_whitening(
   X_design_full,
   Y_residuals_for_AR_fit,
   order = 2L,
-  global_ar_on_design = TRUE
+  global_ar_on_design = TRUE,
+  max_ar_failures_prop = 0.3
 )
 }
 \arguments{
@@ -27,6 +28,11 @@ that accounts for task effects and other known structured noise components.}
 \item{global_ar_on_design}{Logical, if TRUE (default), a global AR model (averaged from successful
 voxel-wise fits) is used to whiten `X_design_full`. If FALSE, `X_design_full` is not whitened,
 and users should handle its whitening if necessary for downstream voxel-wise modeling.}
+
+\item{max_ar_failures_prop}{Numeric between 0 and 1 specifying the maximum
+allowed proportion of voxels with failed or unstable AR fits. If the observed
+proportion exceeds this threshold, whitening is skipped and a warning is
+issued.}
 }
 \value{
 A list containing:

--- a/tests/testthat/test-whitening.R
+++ b/tests/testthat/test-whitening.R
@@ -120,7 +120,8 @@ test_that("ndx_ar2_whitening handles failed AR fits gracefully", {
   Y_residuals_for_AR_fit_sim <- cbind(ar_data1$series, zero_var_residuals)
   X_design_sim <- matrix(rnorm(n_timepoints * 2), n_timepoints, 2)
 
-  whitening_results <- ndx_ar2_whitening(Y_data_sim, X_design_sim, Y_residuals_for_AR_fit_sim, order = ar_order)
+  whitening_results <- ndx_ar2_whitening(Y_data_sim, X_design_sim, Y_residuals_for_AR_fit_sim,
+                                         order = ar_order, max_ar_failures_prop = 0.6)
 
   # Check AR_coeffs_voxelwise for the failed voxel
   expect_equal(whitening_results$AR_coeffs_voxelwise[2, ], c(0,0), 


### PR DESCRIPTION
## Summary
- expose `max_ar_failures_prop` argument in `ndx_ar2_whitening`
- allow workflow to forward the user option
- document new argument and update defaults
- adjust whitening tests for updated API

## Testing
- `Rscript run_tests.R` *(fails: command not found)*