### PR TITLE
Add stability check for global AR whitening

### DIFF
--- a/tests/testthat/test-whitening_global_ar_check.R
+++ b/tests/testthat/test-whitening_global_ar_check.R
@@ -1,0 +1,28 @@
+context("Global AR stability safeguard")
+
+test_that("Unstable averaged AR coefficients skip design whitening", {
+  set.seed(42)
+  n_tp <- 60
+  Y <- matrix(rnorm(n_tp * 2), nrow = n_tp, ncol = 2)
+  X <- matrix(rnorm(n_tp * 2), nrow = n_tp, ncol = 2)
+  Y_res <- Y
+  fake_coeffs <- c(1.2, 0.8)  # purposely unstable
+
+  stub_colMeans <- function(x, na.rm = FALSE, dims = 1) {
+    if (is.matrix(x) && identical(dim(x), c(2L, 2L))) {
+      return(fake_coeffs)
+    } else {
+      base::colMeans(x, na.rm = na.rm, dims = dims)
+    }
+  }
+
+  expect_warning(
+    res <- with_mocked_bindings(
+      colMeans = stub_colMeans,
+      ndx_ar2_whitening(Y, X, Y_res, order = 2L, verbose = FALSE)
+    ),
+    regexp = "Averaged AR coefficients"
+  )
+  expect_null(res$AR_coeffs_global)
+  expect_identical(res$X_whitened, X)
+})


### PR DESCRIPTION
## Summary
- safeguard against unstable averaged AR coefficients when whitening design matrix
- unit test ensures fallback to unwhitened design if averaged AR is unstable

## Testing
- `Rscript run_tests.R` *(fails: Rscript not found)*