### PR TITLE
Add parameter checks for spectral routines

### DIFF
--- a/R/ndx_spectral.R
+++ b/R/ndx_spectral.R
@@ -70,6 +70,25 @@ ndx_spectral_sines <- function(mean_residual_for_spectrum, TR,
     return(NULL)
   }
 
+  default_n_sine_candidates <- 6
+  if (!is.numeric(n_sine_candidates) || length(n_sine_candidates) != 1 ||
+      n_sine_candidates <= 0) {
+    warning(sprintf("n_sine_candidates must be > 0. Using default %d.",
+                    default_n_sine_candidates))
+    n_sine_candidates <- default_n_sine_candidates
+  }
+
+  default_selection_delta_threshold <- 2
+  if (!is.numeric(selection_delta_threshold) ||
+      length(selection_delta_threshold) != 1 ||
+      selection_delta_threshold < 0) {
+    warning(sprintf(
+      "selection_delta_threshold must be >= 0. Using default %.2f.",
+      default_selection_delta_threshold
+    ))
+    selection_delta_threshold <- default_selection_delta_threshold
+  }
+
   # De-mean the series (Feedback 2.1)
   mean_residual_for_spectrum <- base::scale(mean_residual_for_spectrum, center = TRUE, scale = FALSE)[,1]
 
@@ -289,6 +308,15 @@ Select_Significant_Spectral_Regressors <- function(y, U_candidates,
   }
   
   criterion <- match.arg(criterion)
+
+  default_delta_threshold <- 2
+  if (!is.numeric(delta_threshold) || length(delta_threshold) != 1 ||
+      delta_threshold < 0) {
+    warning(sprintf("[Select_SSR] delta_threshold must be >= 0. Using default %.2f.",
+                    default_delta_threshold))
+    delta_threshold <- default_delta_threshold
+  }
+
   n_pairs <- ncol(U_candidates) %/% 2
   
   # If U_candidates is a 0-column matrix (e.g. no peaks from ndx_spectral_sines), n_pairs will be 0

--- a/tests/testthat/test-spectral.R
+++ b/tests/testthat/test-spectral.R
@@ -55,6 +55,41 @@ test_that("ndx_spectral_sines generates correct regressors for a simple signal",
   }
 })
 
+test_that("ndx_spectral_sines warns on invalid n_sine_candidates and falls back to default", {
+  set.seed(999)
+  TR_val <- 1
+  n_tp <- 100
+  t_sec <- (seq_len(n_tp) - 1) * TR_val
+  mean_resid <- sin(2 * pi * 0.1 * t_sec) + rnorm(n_tp, sd = 0.1)
+
+  expect_warning(
+    res_bad <- ndx_spectral_sines(mean_resid, TR = TR_val, n_sine_candidates = -5),
+    "n_sine_candidates must be > 0"
+  )
+  set.seed(999)
+  res_def <- ndx_spectral_sines(mean_resid, TR = TR_val, n_sine_candidates = 6)
+  expect_equal(res_bad, res_def)
+})
+
+test_that("Select_Significant_Spectral_Regressors warns on negative delta_threshold", {
+  set.seed(888)
+  n_tp <- 100; TR <- 1
+  t_sec <- (seq_len(n_tp) - 1) * TR
+  y <- sin(2 * pi * 0.1 * t_sec) + rnorm(n_tp, sd = 0.1)
+  U_pair <- cbind(sin(2 * pi * 0.1 * t_sec), cos(2 * pi * 0.1 * t_sec))
+  colnames(U_pair) <- c("s", "c")
+  attr(U_pair, "freq_hz") <- 0.1
+  attr(U_pair, "freq_rad_s") <- 2 * pi * 0.1
+
+  expect_warning(
+    sel_bad <- Select_Significant_Spectral_Regressors(y, U_pair, delta_threshold = -1, criterion = "BIC"),
+    "delta_threshold must be >= 0"
+  )
+  set.seed(888)
+  sel_def <- Select_Significant_Spectral_Regressors(y, U_pair, delta_threshold = 2, criterion = "BIC")
+  expect_equal(sel_bad, sel_def)
+})
+
 test_that("ndx_spectral_sines handles no clear peaks", {
   set.seed(456)
   TR_val <- 1.0


### PR DESCRIPTION
## Summary
- validate `n_sine_candidates` and `selection_delta_threshold` in `ndx_spectral_sines`
- validate `delta_threshold` in `Select_Significant_Spectral_Regressors`
- add regression tests for invalid parameter cases

## Testing
- `Rscript run_tests.R` *(fails: command not found)*