### PR TITLE
Fix mt_res assignment scope and add test

### DIFF
--- a/R/ndx_spectral.R
+++ b/R/ndx_spectral.R
@@ -110,7 +110,7 @@ ndx_spectral_sines <- function(mean_residual_for_spectrum, TR,
                                    plot    = FALSE)
   }, error = function(e) {
     warning(paste("multitaper::spec.mtm failed:", e$message))
-    mt_res <<- NULL
+    assign("mt_res", NULL, envir = parent.env(environment()))
   })
 
   if (is.null(mt_res) || is.null(mt_res$spec) || is.null(mt_res$freq) || length(mt_res$spec) == 0) {

--- a/tests/testthat/test-ndx_spectral_env.R
+++ b/tests/testthat/test-ndx_spectral_env.R
@@ -1,0 +1,22 @@
+context("ndx_spectral_sines - environment cleanup")
+
+test_that("mt_res is reset locally without affecting global env", {
+  old_exists <- exists("mt_res", envir = globalenv(), inherits = FALSE)
+  if (old_exists) old_val <- get("mt_res", envir = globalenv())
+
+  assign("mt_res", "global_value", envir = globalenv())
+  short_ts <- rnorm(5)
+
+  expect_warning(
+    res <- ndx_spectral_sines(short_ts, TR = 1, n_sine_candidates = 1, k_tapers = 5, nw = 3),
+    "Spectrum estimation via spec.mtm did not yield valid spec or freq."
+  )
+  expect_null(res)
+  expect_identical(get("mt_res", envir = globalenv()), "global_value")
+
+  if (old_exists) {
+    assign("mt_res", old_val, envir = globalenv())
+  } else {
+    rm("mt_res", envir = globalenv())
+  }
+})


### PR DESCRIPTION
## Summary
- avoid `<<-` in ndx_spectral_sines error handler
- use `assign()` with `parent.env(environment())` for local scope reset
- add regression test to verify global environment is unaffected

## Testing
- `Rscript run_tests.R` *(fails: command not found)*