### PR TITLE
Improve ndx_solve_anisotropic_ridge validation

### DIFF
--- a/tests/testthat/test-ridge.R
+++ b/tests/testthat/test-ridge.R
@@ -109,8 +109,18 @@ test_that("ndx_solve_anisotropic_ridge input validation works", {
   expect_warning(ndx_solve_anisotropic_ridge(Y_good, X_good[1:10, ], K_diag_good), "Y_whitened and X_whitened must have the same number of rows", fixed = TRUE)
   expect_warning(ndx_solve_anisotropic_ridge(Y_good, X_good, K_diag_good[1]), "K_penalty_diag must be a numeric vector with length equal to ncol(X_whitened).", fixed = TRUE)
   expect_warning(ndx_solve_anisotropic_ridge(Y_good, X_good, "a"), "K_penalty_diag must be a numeric vector", fixed = TRUE) 
-  expect_warning(ndx_solve_anisotropic_ridge(Y_good, X_good, c(-0.1, 0.1, 0.1)), "All elements of K_penalty_diag must be non-negative", fixed = TRUE) 
+  expect_warning(ndx_solve_anisotropic_ridge(Y_good, X_good, c(-0.1, 0.1, 0.1)), "All elements of K_penalty_diag must be non-negative", fixed = TRUE)
   expect_warning(ndx_solve_anisotropic_ridge(Y_good, X_good, K_diag_good, na_mask=rep(TRUE, 5)), "na_mask must be a logical vector with length equal to nrow(Y_whitened).", fixed = TRUE)
+
+  w_bad_neg <- c(rep(1, nrow(Y_good) - 1), -1)
+  expect_warning(res_neg <- ndx_solve_anisotropic_ridge(Y_good, X_good, K_diag_good, weights = w_bad_neg),
+                 "weights must contain non-negative finite numbers", fixed = TRUE)
+  expect_null(res_neg)
+
+  w_bad_inf <- c(rep(1, nrow(Y_good) - 1), Inf)
+  expect_warning(res_inf <- ndx_solve_anisotropic_ridge(Y_good, X_good, K_diag_good, weights = w_bad_inf),
+                 "weights must contain non-negative finite numbers", fixed = TRUE)
+  expect_null(res_inf)
   
   Y_short_for_warn <- Y_good[1:2, , drop=FALSE]
   X_wide_for_warn <- X_good[1:2, , drop=FALSE] 

--- a/tests/testthat/test-ridge_gcv.R
+++ b/tests/testthat/test-ridge_gcv.R
@@ -18,6 +18,21 @@ test_that("ndx_solve_anisotropic_ridge performs GCV tuning", {
   expect_equal(dim(betas), c(2,1))
 })
 
+test_that("warning when gcv_lambda TRUE but P_Noise missing", {
+  data <- .create_ridge_test_data(40, 2, 1, c(1, -1), noise_sd = 0.5)
+  proj <- ndx_compute_projection_matrices(U_Noise = NULL, n_regressors = 2)
+  res_var <- ndx_estimate_res_var_whitened(data$Y, data$X)
+  expect_warning(
+    betas <- ndx_solve_anisotropic_ridge(data$Y, data$X,
+      projection_mats = proj,
+      lambda_values = list(lambda_parallel = 1, lambda_perp_signal = 0.1),
+      gcv_lambda = TRUE,
+      res_var_scale = res_var),
+    "gcv_lambda = TRUE but projection_mats$P_Noise is missing", fixed = TRUE
+  )
+  expect_equal(dim(betas), c(2,1))
+})
+
 test_that("ndx_gcv_tune_lambda_parallel handles NULL P_Noise", {
   data <- .create_ridge_test_data(30, 2, 1, c(1, -1), noise_sd = 0.2)
   lam <- ndx_gcv_tune_lambda_parallel(data$Y, data$X, NULL,


### PR DESCRIPTION
## Summary
- validate `weights` contain non-negative finite numbers
- warn if `gcv_lambda` is `TRUE` but `projection_mats$P_Noise` is missing
- add tests for weight validation and gcv warning

## Testing
- `Rscript run_tests.R` *(fails: command not found)*