### PR TITLE
Update projection matrix union

### DIFF
--- a/R/ndx_ridge.R
+++ b/R/ndx_ridge.R
@@ -22,10 +22,14 @@ ndx_compute_projection_matrices <- function(U_GD = NULL, U_Unique = NULL,
   P_Unique <- make_proj(U_Unique)
   P_Noise <- make_proj(U_Noise)
 
-  P_combined <- matrix(0, n_regressors, n_regressors)
-  if (!is.null(P_GD)) P_combined <- P_combined + P_GD
-  if (!is.null(P_Unique)) P_combined <- P_combined + P_Unique
-  if (!is.null(P_Noise)) P_combined <- P_combined + P_Noise
+  basis_list <- list(U_GD, U_Unique, U_Noise)
+  non_null <- Filter(function(x) !is.null(x) && ncol(x) > 0, basis_list)
+  if (length(non_null) > 0) {
+    Q_all <- qr.Q(qr(do.call(cbind, non_null)))
+    P_combined <- Q_all %*% t(Q_all)
+  } else {
+    P_combined <- matrix(0, n_regressors, n_regressors)
+  }
   P_Signal <- I_reg - P_combined
 
   list(P_GD = P_GD, P_Unique = P_Unique, P_Noise = P_Noise, P_Signal = P_Signal)

--- a/tests/testthat/test-ridge.R
+++ b/tests/testthat/test-ridge.R
@@ -195,7 +195,8 @@ test_that("ndx_compute_projection_matrices constructs valid projectors", {
   U_noise <- matrix(rnorm(20), nrow = 4)
   proj <- ndx_compute_projection_matrices(U_Noise = U_noise, n_regressors = 4)
   expect_true(all(dim(proj$P_Noise) == c(4,4)))
-  expect_true(all(diag(proj$P_Signal + proj$P_Noise) <= 1.0001))
+  expect_equal(proj$P_Noise + proj$P_Signal, diag(4), tolerance = 1e-6)
+  expect_true(max(abs(proj$P_Noise %*% proj$P_Signal)) < 1e-6)
 })
 
 test_that("ndx_update_lambda_aggressiveness adjusts lambda", {


### PR DESCRIPTION
## Summary
- compute union of bases using `qr()` in `ndx_compute_projection_matrices`
- ensure `P_Signal` comes from complement of combined projector
- test for orthogonality and identity of projectors

## Testing
- `Rscript run_tests.R` *(fails: command not found)*