### PR TITLE
Fix pam_fit assignment scope

### DIFF
--- a/R/ndx_hrf.R
+++ b/R/ndx_hrf.R
@@ -875,7 +875,7 @@ project_hrf_cone <- function(h,
     pam_fit <- cluster::pam(t(Y_for_clustering), k = num_clusters, diss = FALSE, metric="euclidean", stand = FALSE)
   }, error = function(e) {
     warning(sprintf("K-Medoids clustering (pam) failed: %s. Assigning all to cluster 1.", e$message))
-    pam_fit <<- NULL # Ensure it's NULL in outer scope on error
+    pam_fit <- NULL # Keep pam_fit local on error
   })
   
   if (is.null(pam_fit)) {


### PR DESCRIPTION
## Summary
- assign `pam_fit` locally in `.perform_hrf_clustering()`

## Testing
- `Rscript run_tests.R` *(fails: Rscript not found)*