### PR TITLE
Add unit tests for GLMdenoise utilities

### DIFF
--- a/tests/testthat/test-calculate_tsnr.R
+++ b/tests/testthat/test-calculate_tsnr.R
@@ -1,0 +1,25 @@
+context("calculate_tsnr")
+
+test_that("basic tSNR computation", {
+  set.seed(123)
+  noise <- matrix(rnorm(20 * 2, sd = 2), nrow = 20, ncol = 2)
+  signal <- matrix(5, nrow = 20, ncol = 2)
+  Y <- signal + noise
+  tsnr <- calculate_tsnr(Y, detrend = FALSE)
+  manual <- colMeans(Y) / apply(Y, 2, sd)
+  expect_equal(tsnr, manual, tolerance = 1e-6)
+})
+
+test_that("detrending removes linear trends", {
+  time <- 1:10
+  Y <- cbind(time, rnorm(10))
+  tsnr_dt <- calculate_tsnr(Y, detrend = TRUE)
+  expect_true(is.na(tsnr_dt[1]))
+  expect_true(!is.na(tsnr_dt[2]))
+})
+
+test_that("zero variance voxels produce NA", {
+  Y <- matrix(3, nrow = 5, ncol = 2)
+  tsnr <- calculate_tsnr(Y)
+  expect_true(all(is.na(tsnr)))
+})

--- a/tests/testthat/test-cv_r2_loro.R
+++ b/tests/testthat/test-cv_r2_loro.R
@@ -1,0 +1,32 @@
+context("cv_r2_loro")
+
+test_that("perfectly predicted data yields R2 of one", {
+  n_runs <- 2
+  n_per_run <- 4
+  run_idx <- rep(1:n_runs, each = n_per_run)
+  time <- 1:(n_runs * n_per_run)
+
+  X <- cbind(1, sin(time))
+  betas <- matrix(c(2, 3), nrow = 2)
+  Y <- X %*% betas
+
+  r2 <- cv_r2_loro(Y, X, run_idx)
+  expect_equal(r2, rep(1, ncol(Y)))
+})
+
+test_that("design matrix with zero columns returns zeros", {
+  Y <- matrix(rnorm(10 * 3), nrow = 10)
+  X <- matrix(nrow = 10, ncol = 0)
+  run_idx <- rep(1:2, each = 5)
+  expect_warning(r2 <- cv_r2_loro(Y, X, run_idx))
+  expect_equal(r2, rep(0, ncol(Y)))
+})
+
+test_that("voxels with zero variance give R2 of zero", {
+  run_idx <- rep(1:2, each = 3)
+  X <- matrix(1, nrow = 6, ncol = 1)
+  Y <- cbind(rep(5, 6), rnorm(6))
+  r2 <- cv_r2_loro(Y, X, run_idx)
+  expect_equal(r2[1], 0)
+  expect_true(r2[2] >= 0 && r2[2] <= 1)
+})

--- a/tests/testthat/test-gdlite_pcs.R
+++ b/tests/testthat/test-gdlite_pcs.R
@@ -1,0 +1,39 @@
+context("ndx_extract_gdlite_pcs")
+
+test_that("valid extraction with and without mask", {
+  set.seed(123)
+  Y <- matrix(rnorm(20 * 10), nrow = 20, ncol = 10)
+  X <- matrix(1, nrow = 20, ncol = 1)
+
+  pcs_nomask <- ndx_extract_gdlite_pcs(Y, X, n_pcs = 2)
+  expect_true(is.matrix(pcs_nomask))
+  expect_equal(dim(pcs_nomask), c(20, 2))
+
+  mask <- rep(c(TRUE, FALSE), length.out = 10)
+  pcs_mask <- ndx_extract_gdlite_pcs(Y, X, n_pcs = 2, voxel_mask = mask)
+  expect_true(is.matrix(pcs_mask))
+  expect_equal(dim(pcs_mask), c(20, 2))
+})
+
+test_that("empty noise pool due to mask returns NULL", {
+  set.seed(1)
+  Y <- matrix(rnorm(10 * 5), nrow = 10, ncol = 5)
+  X <- matrix(1, nrow = 10, ncol = 1)
+  mask_none <- rep(FALSE, 5)
+  expect_warning(res <- ndx_extract_gdlite_pcs(Y, X, n_pcs = 2, voxel_mask = mask_none))
+  expect_null(res)
+})
+
+test_that("zero variance voxels return NULL", {
+  Y <- matrix(5, nrow = 8, ncol = 4)  # constant data
+  X <- matrix(1, nrow = 8, ncol = 1)
+  expect_warning(res <- ndx_extract_gdlite_pcs(Y, X, n_pcs = 1))
+  expect_null(res)
+})
+
+test_that("invalid inputs trigger errors", {
+  Y <- matrix(rnorm(10), nrow = 5)
+  X <- matrix(1, nrow = 5, ncol = 1)
+  expect_error(ndx_extract_gdlite_pcs(list(1,2,3), X, n_pcs = 2))
+  expect_error(ndx_extract_gdlite_pcs(Y, list(), n_pcs = 2))
+})


### PR DESCRIPTION
## Summary
- add new unit tests for `ndx_extract_gdlite_pcs`
- add coverage for `cv_r2_loro`
- add tests for `calculate_tsnr`

## Testing
- `Rscript run_tests.R` *(fails: Rscript not found)*