### PR TITLE
Add beta stability and Ljung-Box diagnostics

### DIFF
--- a/R/ndx_diagnostics.R
+++ b/R/ndx_diagnostics.R
@@ -3,8 +3,9 @@
 #' This function creates a simple HTML report summarizing key diagnostics from
 #' a run of `NDX_Process_Subject`. It plots the Denoising Efficacy Score (DES)
 #' across passes, compares the power spectral density (PSD) of residuals from
-#' Pass 0 and the final ND-X pass, and optionally shows a spike "carpet" plot
-#' from the RPCA `S` matrix.
+#' Pass 0 and the final ND-X pass, visualizes \eqn{\beta}-stability across runs,
+#' shows the Ljung--Box p-value progression, and optionally displays a spike
+#' "carpet" plot from the RPCA `S` matrix.
 #'
 #' @param workflow_output List returned by `NDX_Process_Subject`.
 #' @param pass0_residuals Matrix of residuals from `ndx_initial_glm` used as the
@@ -43,6 +44,22 @@ ndx_generate_html_report <- function(workflow_output,
                  main = "Denoising Efficacy Score per Pass")
   grDevices::dev.off()
 
+  # ---- Beta stability plot ----
+  beta_png <- NULL
+  if (!is.null(workflow_output$beta_history_per_pass)) {
+    beta_vals <- tryCatch(
+      calculate_beta_stability(workflow_output$beta_history_per_pass),
+      error = function(e) rep(NA_real_, length(workflow_output$beta_history_per_pass))
+    )
+    beta_png <- file.path(output_dir, "beta_stability_per_pass.png")
+    grDevices::png(beta_png, width = 600, height = 400)
+    graphics::plot(seq_along(beta_vals), beta_vals, type = "b",
+                   xlab = "Pass", ylab = "Beta Stability",
+                   ylim = c(-1, 1),
+                   main = "\u03B2-Stability Across Runs")
+    grDevices::dev.off()
+  }
+
   # ---- Residual PSD plot ----
   psd_png <- file.path(output_dir, "residual_psd.png")
   if (!is.null(workflow_output$Y_residuals_final_unwhitened)) {
@@ -60,6 +77,23 @@ ndx_generate_html_report <- function(workflow_output,
     grDevices::dev.off()
   } else {
     psd_png <- NULL
+  }
+
+  # ---- Ljung-Box p-value plot ----
+  ljung_png <- NULL
+  if (!is.null(workflow_output$diagnostics_per_pass)) {
+    ljung_vals <- sapply(workflow_output$diagnostics_per_pass,
+                         function(d) d$ljung_box_p)
+    if (any(!is.na(ljung_vals))) {
+      ljung_png <- file.path(output_dir, "ljung_box_pvalues.png")
+      grDevices::png(ljung_png, width = 600, height = 400)
+      graphics::plot(seq_along(ljung_vals), ljung_vals, type = "b",
+                     xlab = "Pass", ylab = "Ljung-Box p-value",
+                     ylim = c(0, 1),
+                     main = "Residual Whiteness (Ljung-Box)")
+      graphics::abline(h = 0.05, col = "red", lty = 2)
+      grDevices::dev.off()
+    }
   }
 
   # ---- Spike carpet plot ----
@@ -132,12 +166,32 @@ ndx_generate_html_report <- function(workflow_output,
     "</div>"
   )
 
+  # ---- Add beta stability section ----
+  if (!is.null(beta_png)) {
+    html_lines <- c(html_lines,
+      "<div class='section'>",
+      "<h2>&beta;-Stability Across Runs</h2>",
+      sprintf("<img src='%s' alt='Beta stability'>", basename(beta_png)),
+      "</div>"
+    )
+  }
+
   # ---- Add PSD section ----
   if (!is.null(psd_png)) {
     html_lines <- c(html_lines,
       "<div class='section'>",
       "<h2>Residual Power Spectral Density</h2>",
       sprintf("<img src='%s' alt='Residual PSD'>", basename(psd_png)),
+      "</div>"
+    )
+  }
+
+  # ---- Add Ljung-Box section ----
+  if (!is.null(ljung_png)) {
+    html_lines <- c(html_lines,
+      "<div class='section'>",
+      "<h2>Ljung-Box p-value per Pass</h2>",
+      sprintf("<img src='%s' alt='Ljung-Box p-values'>", basename(ljung_png)),
       "</div>"
     )
   }

--- a/man/ndx_generate_html_report.Rd
+++ b/man/ndx_generate_html_report.Rd
@@ -20,6 +20,7 @@ ndx_generate_html_report(workflow_output, pass0_residuals, TR,
 \value{Path to the generated HTML file (invisibly).}
 \description{
 Creates a minimal HTML report summarizing ND-X diagnostics: DES per pass,
+\eqn{\beta}-stability across runs, Ljung-Box whiteness of residuals,
 residual power spectral density comparison, an optional spike carpet plot,
 and key adaptive hyperparameter values.
 }

--- a/tests/testthat/test-diagnostics.R
+++ b/tests/testthat/test-diagnostics.R
@@ -38,6 +38,8 @@ test_that("HTML report is generated", {
     html_path <- ndx_generate_html_report(workflow_mock, pass0_res, TR_test, output_dir = tmpdir)
   })
   expect_true(file.exists(file.path(tmpdir, "ndx_diagnostic_report.html")))
+  expect_true(file.exists(file.path(tmpdir, "beta_stability_per_pass.png")))
+  expect_true(file.exists(file.path(tmpdir, "ljung_box_pvalues.png")))
 })
 
 test_that("JSON certificate is generated with expected fields", {


### PR DESCRIPTION
## Summary
- report beta stability and Ljung–Box p-value in `ndx_generate_html_report`
- show the new plots in the HTML report
- document new metrics in the manual
- extend diagnostics test to check generated PNG files

## Testing
- `Rscript run_tests.R` *(fails: command not found)*