### PR TITLE
Fix EOF newline in ndx_design_matrix.R

### DIFF
--- a/R/ndx_design_matrix.R
+++ b/R/ndx_design_matrix.R
@@ -342,4 +342,4 @@ ndx_build_design_matrix <- function(estimated_hrfs,
     }
   }
   return(X_combined)
-} 
+}


### PR DESCRIPTION
## Summary
- ensure `ndx_design_matrix.R` ends with a newline

## Testing
- `Rscript run_tests.R` *(fails: command not found)*