### PR TITLE
Add zero_var_epsilon option

### DIFF
--- a/R/ndx_design_matrix.R
+++ b/R/ndx_design_matrix.R
@@ -15,6 +15,9 @@
 #' @param poly_degree Degree of Legendre polynomial baseline (per run).
 #' @param verbose Logical flag for verbose console output.
 #' @param drop_zero_variance Logical flag to drop near-zero variance regressors.
+#' @param zero_var_epsilon Numeric tolerance for detecting near-zero variance
+#'   regressors. Columns with variance below this value are considered
+#'   near-constant. Default is 1e-8.
 #'
 #' @return Numeric matrix with one column per regressor (or `NULL` on failure).
 #' @importFrom fmrireg sampling_frame event_model design_matrix baseline_model
@@ -29,7 +32,8 @@ ndx_build_design_matrix <- function(estimated_hrfs,
                                     TR,
                                     poly_degree = NULL,
                                     verbose = TRUE,
-                                    drop_zero_variance = FALSE) {
+                                    drop_zero_variance = FALSE,
+                                    zero_var_epsilon = 1e-8) {
 
   # 1. Basic validation ----------------------------------------------------
   info <- .ndx_validate_design_inputs(run_idx, motion_params, rpca_components, spectral_sines)
@@ -47,7 +51,8 @@ ndx_build_design_matrix <- function(estimated_hrfs,
   # 5. Combine -------------------------------------------------------------
   regressor_list <- c(list(task = task_mat), nuisance_list_components, list(baseline = baseline_mat))
   X_full <- .ndx_combine_regressors(regressor_list, info$total_tp,
-                                    verbose, drop_zero_variance)
+                                    verbose, drop_zero_variance,
+                                    zero_var_epsilon)
 
   if (verbose && !is.null(X_full)) {
     message(sprintf("Constructed X_full_design with %d timepoints and %d regressors.", 
@@ -284,10 +289,12 @@ ndx_build_design_matrix <- function(estimated_hrfs,
 }
 
 #' @keywords internal
+#' @param zero_var_epsilon Numeric tolerance for detecting near-zero variance columns.
 .ndx_combine_regressors <- function(reg_list,
                                    total_tp,
                                    verbose = TRUE,
-                                   drop_zero_variance = FALSE) {
+                                   drop_zero_variance = FALSE,
+                                   zero_var_epsilon = 1e-8) {
   valid_components <- list()
   for (name in names(reg_list)) {
     comp <- reg_list[[name]]
@@ -329,7 +336,7 @@ ndx_build_design_matrix <- function(estimated_hrfs,
 
   if (!is.null(X_combined) && ncol(X_combined) > 0) {
     col_vars <- apply(X_combined, 2, stats::var, na.rm = TRUE)
-    potential_zero_var_cols <- colnames(X_combined)[col_vars < (.Machine$double.eps * 100)]
+    potential_zero_var_cols <- colnames(X_combined)[col_vars < zero_var_epsilon]
     intercept_patterns <- "^(poly0|intercept|run_intercept_)"
     zero_var_cols_to_warn <- potential_zero_var_cols[!grepl(intercept_patterns, potential_zero_var_cols, ignore.case = TRUE)]
     if (length(zero_var_cols_to_warn) > 0 && verbose) {

--- a/man/ndx_build_design_matrix.Rd
+++ b/man/ndx_build_design_matrix.Rd
@@ -13,7 +13,9 @@ ndx_build_design_matrix(
   run_idx,
   TR,
   poly_degree = NULL,
-  verbose = TRUE
+  verbose = TRUE,
+  drop_zero_variance = FALSE,
+  zero_var_epsilon = 1e-8
 )
 }
 \arguments{
@@ -34,6 +36,10 @@ ndx_build_design_matrix(
 \item{poly_degree}{Degree of Legendre polynomial baseline (per run).}
 
 \item{verbose}{Logical flag for verbose console output.}
+
+\item{drop_zero_variance}{Logical flag to drop near-zero variance regressors.}
+
+\item{zero_var_epsilon}{Numeric tolerance for detecting near-zero variance regressors.}
 }
 \value{
 Numeric matrix with one column per regressor (or `NULL` on failure).

--- a/tests/testthat/test-design_matrix.R
+++ b/tests/testthat/test-design_matrix.R
@@ -330,3 +330,22 @@ test_that("drop_zero_variance option removes constant regressors", {
   )
   expect_false("rpca_comp_1" %in% colnames(X_drop))
 })
+
+test_that("near-constant regressors are removed when variance below epsilon", {
+  set.seed(123)
+  near_const_rpca <- matrix(1 + rnorm(total_timepoints_dm, sd = 1e-10), ncol = 1)
+  X_drop_near <- ndx_build_design_matrix(
+    estimated_hrfs = estimated_hrfs_dm,
+    events = events_dm,
+    motion_params = motion_params_dm,
+    rpca_components = near_const_rpca,
+    spectral_sines = NULL,
+    run_idx = run_idx_dm,
+    TR = TR_test_dm,
+    poly_degree = 0,
+    verbose = FALSE,
+    drop_zero_variance = TRUE,
+    zero_var_epsilon = 1e-8
+  )
+  expect_false("rpca_comp_1" %in% colnames(X_drop_near))
+})


### PR DESCRIPTION
## Summary
- allow passing `zero_var_epsilon` to `ndx_build_design_matrix`
- propagate epsilon to `.ndx_combine_regressors`
- update manual page
- test near constant regressors

## Testing
- `Rscript run_tests.R` *(fails: command not found)*