### PR TITLE
Map and validate run indices

### DIFF
--- a/R/ndx_design_matrix.R
+++ b/R/ndx_design_matrix.R
@@ -35,6 +35,19 @@ ndx_build_design_matrix <- function(estimated_hrfs,
   info <- .ndx_validate_design_inputs(run_idx, motion_params, rpca_components, spectral_sines)
   sf   <- fmrireg::sampling_frame(blocklens = info$run_lengths, TR = TR)
 
+  mapped_run_idx <- info$run_idx_mapped
+
+  if (!is.null(events) && "blockids" %in% names(events)) {
+    if (any(is.na(events$blockids) | !is.finite(events$blockids) |
+            events$blockids != floor(events$blockids))) {
+      stop("events$blockids contains NA, non-finite, or non-integer values.")
+    }
+    if (!all(as.character(events$blockids) %in% names(info$run_mapping))) {
+      stop("events$blockids contain values not present in run_idx.")
+    }
+    events$blockids <- as.integer(info$run_mapping[as.character(events$blockids)])
+  }
+
   # 2. Task regressors -----------------------------------------------------
   task_mat <- .ndx_generate_task_regressors(estimated_hrfs, events, sf, TR, verbose)
 
@@ -42,7 +55,7 @@ ndx_build_design_matrix <- function(estimated_hrfs,
   nuisance_list_components <- .ndx_generate_nuisance_regressors(motion_params, rpca_components, spectral_sines, verbose)
   
   # 4. Baseline regressors -------------------------------------------------
-  baseline_mat <- .ndx_generate_baseline_regressors(run_idx, sf, poly_degree, verbose)
+  baseline_mat <- .ndx_generate_baseline_regressors(mapped_run_idx, sf, poly_degree, verbose)
 
   # 5. Combine -------------------------------------------------------------
   regressor_list <- c(list(task = task_mat), nuisance_list_components, list(baseline = baseline_mat))
@@ -67,8 +80,23 @@ ndx_build_design_matrix <- function(estimated_hrfs,
                                         motion_params,
                                         rpca_components,
                                         spectral_sines) {
-  unique_runs <- sort(unique(run_idx))
-  run_lengths <- as.numeric(table(factor(run_idx, levels = unique_runs)))
+  if (length(run_idx) == 0) {
+    stop("run_idx implies one or more runs have zero or negative length.")
+  }
+
+  if (any(is.na(run_idx) | !is.finite(run_idx))) {
+    stop("run_idx contains NA or non-finite values.")
+  }
+
+  if (any(run_idx != floor(run_idx))) {
+    stop("run_idx must contain integer values only.")
+  }
+
+  unique_vals <- sort(unique(run_idx))
+  run_mapping <- setNames(seq_along(unique_vals), as.character(unique_vals))
+  run_idx_mapped <- as.integer(run_mapping[as.character(run_idx)])
+  unique_runs <- sort(unique(run_idx_mapped))
+  run_lengths <- as.numeric(table(factor(run_idx_mapped, levels = unique_runs)))
 
   if (length(run_lengths) == 0 || sum(run_lengths) == 0) {
     stop("run_idx implies one or more runs have zero or negative length.")
@@ -91,7 +119,9 @@ ndx_build_design_matrix <- function(estimated_hrfs,
 
   list(unique_runs   = unique_runs,
        run_lengths   = run_lengths,
-       total_tp      = total_tp)
+       total_tp      = total_tp,
+       run_idx_mapped = run_idx_mapped,
+       run_mapping   = run_mapping)
 }
 
 #' @keywords internal
@@ -108,6 +138,20 @@ ndx_build_design_matrix <- function(estimated_hrfs,
   }
   if (!all(c("condition", "hrf_estimate") %in% names(estimated_hrfs))) {
     stop("estimated_hrfs tibble must contain 'condition' and 'hrf_estimate' columns.")
+  }
+
+  if (!is.null(events) && nrow(events) > 0) {
+    if (!("blockids" %in% names(events))) {
+      stop("events data frame must contain a 'blockids' column.")
+    }
+    n_runs <- length(sf$blocklens)
+    if (any(is.na(events$blockids) | !is.finite(events$blockids) |
+            events$blockids != floor(events$blockids))) {
+      stop("events$blockids must be finite integers.")
+    }
+    if (any(!(events$blockids %in% seq_len(n_runs)))) {
+      stop("events$blockids values outside range of run indices.")
+    }
   }
 
   task_designs_list <- list()
@@ -224,6 +268,9 @@ ndx_build_design_matrix <- function(estimated_hrfs,
                                              poly_degree,
                                              verbose = TRUE) {
   if (verbose) message(sprintf("  Generating baseline regressors (poly_degree: %s)...", ifelse(is.null(poly_degree), "NULL", poly_degree))) # Kept one high-level
+  if (any(is.na(run_idx) | !is.finite(run_idx) | run_idx != floor(run_idx))) {
+    stop("run_idx for baseline must be finite integer values.")
+  }
   unique_runs <- sort(unique(run_idx))
   total_tp    <- length(run_idx)
   baseline    <- list()

--- a/tests/testthat/test-design_matrix.R
+++ b/tests/testthat/test-design_matrix.R
@@ -330,3 +330,47 @@ test_that("drop_zero_variance option removes constant regressors", {
   )
   expect_false("rpca_comp_1" %in% colnames(X_drop))
 })
+
+test_that("non-sequential run_idx are mapped correctly", {
+  run_idx_ns <- rep(c(10, 20), each = n_time_per_run_dm)
+  events_ns <- events_dm
+  events_ns$blockids <- c(10, 10, 20, 20)
+
+  info <- ndx:::.ndx_validate_design_inputs(run_idx_ns, motion_params_dm,
+                                            rpca_comps_dm, spectral_sines_dm)
+  expect_equal(unique(info$run_idx_mapped), c(1, 2))
+  expect_equal(info$run_lengths, c(n_time_per_run_dm, n_time_per_run_dm))
+
+  X_ns <- ndx_build_design_matrix(
+    estimated_hrfs = estimated_hrfs_dm,
+    events = events_ns,
+    motion_params = motion_params_dm,
+    rpca_components = rpca_comps_dm,
+    spectral_sines = spectral_sines_dm,
+    run_idx = run_idx_ns,
+    TR = TR_test_dm,
+    poly_degree = 1,
+    verbose = FALSE
+  )
+  expect_true(is.matrix(X_ns))
+  expect_equal(nrow(X_ns), total_timepoints_dm)
+})
+
+test_that("run_idx with NA triggers error", {
+  bad_run_idx <- run_idx_dm
+  bad_run_idx[5] <- NA
+  expect_error(
+    ndx_build_design_matrix(
+      estimated_hrfs = estimated_hrfs_dm,
+      events = events_dm,
+      motion_params = motion_params_dm,
+      rpca_components = rpca_comps_dm,
+      spectral_sines = spectral_sines_dm,
+      run_idx = bad_run_idx,
+      TR = TR_test_dm,
+      poly_degree = 1,
+      verbose = FALSE
+    ),
+    "run_idx contains NA"
+  )
+})


### PR DESCRIPTION
## Summary
- enforce stricter validation of `run_idx`
- map run indices to sequential integers and propagate mapping
- validate and remap event `blockids`
- check baseline inputs
- add tests for mapping and NA failures

## Testing
- `Rscript run_tests.R` *(fails: Rscript not found)*