### PR TITLE
Add unit tests for gdlite selection and run functions

### DIFF
--- a/tests/testthat/test-run_gdlite.R
+++ b/tests/testthat/test-run_gdlite.R
@@ -1,0 +1,41 @@
+context("ndx_run_gdlite")
+
+test_that("run_gdlite returns expected structure on toy data", {
+  set.seed(1)
+  n_time <- 6
+  run_idx <- rep(1:2, each = 3)
+  TR <- 1.0
+  Y <- matrix(rnorm(n_time * 4), n_time, 4)
+
+  events <- data.frame(
+    onsets = c(0, 3),
+    durations = c(1, 1),
+    condition = "A",
+    blockids = 1:2
+  )
+
+  res <- ndx_run_gdlite(
+    Y_fmri = Y,
+    events = events,
+    run_idx = run_idx,
+    TR = TR,
+    poly_degree = 0,
+    k_max = 2,
+    r2_thresh_noise_pool = 0,
+    tsnr_thresh_noise_pool = -Inf,
+    r2_thresh_good_voxels = 0,
+    detrend_for_tsnr = FALSE,
+    perform_final_glm = FALSE
+  )
+
+  expect_true(is.list(res))
+  expect_true(all(c("selected_pcs", "K_star", "X_gd") %in% names(res)))
+  if (res$K_star > 0) {
+    expect_true(is.matrix(res$selected_pcs))
+    expect_equal(nrow(res$selected_pcs), n_time)
+    expect_equal(ncol(res$selected_pcs), res$K_star)
+  } else {
+    expect_null(res$selected_pcs)
+  }
+  expect_true(is.matrix(res$X_gd))
+})

--- a/tests/testthat/test-select_optimal_k_gdlite.R
+++ b/tests/testthat/test-select_optimal_k_gdlite.R
@@ -1,0 +1,33 @@
+context("select_optimal_k_gdlite")
+
+test_that("optimal K is selected on simple synthetic data", {
+  set.seed(123)
+  n_time <- 20
+  run_idx <- rep(1:2, each = n_time/2)
+
+  # base design: intercept and simple task regressor
+  task <- rep(c(0, 1), length.out = n_time)
+  X_base <- cbind(1, task)
+
+  # dominant noise component (pc1)
+  pc1 <- scale(seq_len(n_time), center = TRUE, scale = FALSE)
+  pc1 <- pc1 / sqrt(sum(pc1^2))
+  all_pcs <- cbind(pc1, rev(pc1))
+
+  # generate data for 3 voxels
+  betas <- matrix(c(1, 0.5, 0.2, 0.3, -0.1, 0.4), nrow = 2)
+  Y_signal <- X_base %*% betas
+  noise <- tcrossprod(pc1, c(2, 1, 1.5))
+  Y_fmri <- Y_signal + noise
+
+  good_mask <- rep(TRUE, 3)
+
+  res <- select_optimal_k_gdlite(Y_fmri, X_base, all_pcs,
+                                 run_idx, good_mask,
+                                 K_max = 2, min_K = 0)
+
+  expect_equal(res$K_star, 1)
+  expect_true(is.matrix(res$selected_pcs))
+  expect_equal(ncol(res$selected_pcs), 1)
+  expect_equal(nrow(res$selected_pcs), n_time)
+})


### PR DESCRIPTION
## Summary
- add test for `select_optimal_k_gdlite` to verify `K_star` on synthetic data
- add test for `ndx_run_gdlite` ensuring expected output structure on toy dataset

## Testing
- `Rscript run_tests.R` *(fails: command not found)*