### PR TITLE
Refactor multirun RPCA with helpers

### DIFF
--- a/R/ndx_rpca.R
+++ b/R/ndx_rpca.R
@@ -78,10 +78,10 @@
 #' @importFrom rpca rpca
 #' @import stats
 #' @export
-ndx_rpca_temporal_components_multirun <- function(Y_residuals_cat, run_idx, 
+ndx_rpca_temporal_components_multirun <- function(Y_residuals_cat, run_idx,
                                                 k_global_target, user_options = list()) {
 
-  # --- 1. Input Validation & Options --- 
+  # --- 1. Input Validation & Options ---
   if (!is.matrix(Y_residuals_cat) || !is.numeric(Y_residuals_cat)) {
     stop("Y_residuals_cat must be a numeric matrix (total_timepoints x voxels).")
   }
@@ -109,363 +109,82 @@ ndx_rpca_temporal_components_multirun <- function(Y_residuals_cat, run_idx,
     rpca_spike_percentile_thresh = 0.98
   )
   current_opts <- utils::modifyList(default_opts, user_options)
-  
+
   # Ensure k_per_run_target is reasonable
   if (current_opts$k_per_run_target < k_global_target && current_opts$k_per_run_target > 0) {
-      message(sprintf("k_per_run_target (%d) is less than k_global_target (%d). Will use k_per_run_target=%d for per-run RPCA.",
-                      current_opts$k_per_run_target, k_global_target, current_opts$k_per_run_target))
+    message(sprintf("k_per_run_target (%d) is less than k_global_target (%d). Will use k_per_run_target=%d for per-run RPCA.",
+                    current_opts$k_per_run_target, k_global_target, current_opts$k_per_run_target))
   } else if (current_opts$k_per_run_target <= 0) {
-       message(sprintf("k_per_run_target (%d) is <=0. Setting to k_global_target (%d) for per-run RPCA.",
-                      current_opts$k_per_run_target, k_global_target))
-      current_opts$k_per_run_target <- k_global_target
+    message(sprintf("k_per_run_target (%d) is <=0. Setting to k_global_target (%d) for per-run RPCA.",
+                    current_opts$k_per_run_target, k_global_target))
+    current_opts$k_per_run_target <- k_global_target
   }
-  
+
   # Split concatenated residuals into a list of per-run matrices
   unique_runs <- sort(unique(run_idx))
   if (length(unique_runs) == 0) {
     stop("No runs found in run_idx.")
   }
-  
+
   Y_residuals_list <- lapply(unique_runs, function(r_id) {
     Y_residuals_cat[run_idx == r_id, , drop = FALSE]
   })
   names(Y_residuals_list) <- paste0("run_", unique_runs)
 
   if (length(Y_residuals_list) == 0) {
-      warning("Splitting Y_residuals_cat by run_idx resulted in an empty list.")
-      return(NULL)
+    warning("Splitting Y_residuals_cat by run_idx resulted in an empty list.")
+    return(NULL)
   }
-  
-  # --- 2. Per-Run RPCA (on E_r^T) --- 
-  V_list <- list() # To store V_r (voxel-space components from each run)
+
+  # --- 2. Per-Run RPCA ---
+  V_list <- list()
   glitch_ratios_per_run <- numeric(length(Y_residuals_list))
   names(glitch_ratios_per_run) <- names(Y_residuals_list)
   per_run_spike_TR_masks <- vector("list", length(Y_residuals_list))
   names(per_run_spike_TR_masks) <- names(Y_residuals_list)
-  S_matrix_list_per_run_TpV <- list() # To store S_r (Time x Voxels) for each run
-  V_global_singular_values <- NULL # To store singular values for rank adaptation
+  S_matrix_list_per_run_TpV <- list()
+  V_global_singular_values <- NULL
 
   message(sprintf("Starting per-run RPCA for %d runs...", length(Y_residuals_list)))
   for (r_idx in seq_along(Y_residuals_list)) {
     run_name <- names(Y_residuals_list)[r_idx]
-    Er <- Y_residuals_list[[r_idx]] # Time_r x Voxels
-    
-    # Initialize spike mask for this run to all FALSE.
-    # This ensures it's populated even if later steps fail for this run.
-    # Also ensures it has an entry if a run is skipped early.
-    if (nrow(Er) > 0) {
-        per_run_spike_TR_masks[[run_name]] <- rep(FALSE, nrow(Er))
+    Er <- Y_residuals_list[[r_idx]]
+    res <- .ndx_rpca_single_run(Er, run_name, current_opts)
+    V_list[[run_name]] <- res$V_r
+    glitch_ratios_per_run[run_name] <- res$glitch_ratio
+    per_run_spike_TR_masks[[run_name]] <- res$spike_mask
+    if (!is.null(res$S_r_t)) {
+      S_matrix_list_per_run_TpV[[run_name]] <- t(res$S_r_t)
     } else {
-        # If Er is empty, the mask should also be empty for unlist to work correctly later
-        # Or handle this case specifically where Y_residuals_list has 0-row entries.
-        # For now, if Er has 0 rows, this run will likely be skipped anyway.
-        # Let's assume nrow(Er) > 0 if we reach here for spike mask generation.
-        # The existing check below handles empty Er for RPCA itself.
+      S_matrix_list_per_run_TpV[[run_name]] <- matrix(0, nrow = nrow(Er), ncol = ncol(Er))
     }
-    
-    if (nrow(Er) == 0 || ncol(Er) == 0) {
-        warning(sprintf("Residuals for run %s are empty (dims: %s). Skipping RPCA for this run.", 
-                        run_name, paste(dim(Er), collapse="x")))
-        V_list[[run_name]] <- NULL # Placeholder for potential later filtering
-        glitch_ratios_per_run[run_name] <- NA
-        # per_run_spike_TR_masks[[run_name]] already set to FALSE vector of length nrow(Er) if nrow(Er) > 0
-        # or remains NULL if nrow(Er) was 0 (which unlist handles by skipping)
-        # To be safe, if nrow(Er) == 0, assign logical(0)
-        if (nrow(Er) == 0) per_run_spike_TR_masks[[run_name]] <- logical(0)
-        next
-    }
-    
-    Er_t <- t(Er) # Voxels x Time_r
-    
-    # Lambda for this run's RPCA
-    lambda_r <- if (current_opts$rpca_lambda_auto) {
-      1 / sqrt(max(dim(Er_t))) 
-    } else {
-      if (is.null(current_opts$rpca_lambda_fixed)) stop("rpca_lambda_fixed must be provided if rpca_lambda_auto is FALSE.")
-      current_opts$rpca_lambda_fixed
-    }
-    
-    # Prepare arguments for rpca::rpca
-    # We will only pass 'mu' if current_opts$rpca_mu is not NULL,
-    # allowing rpca::rpca to use its internal default and auto-tuning otherwise.
-    rpca_call_args <- list(
-      M = Er_t,
-      lambda = lambda_r,
-      term.delta = current_opts$rpca_term_delta,
-      max.iter = current_opts$rpca_max_iter,
-      trace = current_opts$rpca_trace
-    )
-    
-    if (!is.null(current_opts$rpca_mu)) {
-      # Only add mu to the call if it's specified by the user
-      # Otherwise, rpca package will use its own default: prod(dim(A))/(4*sum(abs(A))) and may auto-tune.
-      # Explicitly calculating mu like: mu_r <- prod(dim(Er_t)) / (4 * sum(abs(Er_t)))
-      # and passing it seemed to cause issues in tests, possibly overriding internal tuning.
-      rpca_call_args$mu <- current_opts$rpca_mu
-      message(sprintf("  Run %s: Using user-specified mu = %f for rpca.", run_name, current_opts$rpca_mu))
-    } else {
-      # Calculate our 'default' mu for logging/messaging if needed, but don't pass it to rpca()
-      # This way, we rely on rpca's internal default mu handling.
-      temp_mu_for_logging <- NA
-      if (sum(abs(Er_t)) > 1e-9) {
-        temp_mu_for_logging <- prod(dim(Er_t)) / (4 * sum(abs(Er_t)))
-      } else {
-        temp_mu_for_logging <- 1.0 # Fallback for logging if Er_t is zero
-      }
-      message(sprintf("  Run %s: rpca_mu is NULL, rpca::rpca will use its internal default mu (approx for logging: %.2e).", 
-                      run_name, temp_mu_for_logging))
-    }
-    
-    # k for this run's RPCA (target rank of L component of Er_t)
-    # Should not exceed min(dim(Er_t))
-    k_this_run <- min(current_opts$k_per_run_target, min(dim(Er_t)))
-    if (k_this_run <= 0) {
-        warning(sprintf("Cannot perform RPCA for run %s: k_this_run (%d) is not positive after adjustment. Skipping.", run_name, k_this_run))
-        V_list[[run_name]] <- NULL
-        glitch_ratios_per_run[run_name] <- NA
-        next
-    }
-    
-    message(sprintf("  Processing run %s (data: %d voxels x %d TRs, target k: %d, lambda: %.2e)", 
-                    run_name, nrow(Er_t), ncol(Er_t), k_this_run, lambda_r))
-    
-    rpca_res_r <- NULL
-    tryCatch({
-      rpca_res_r <- do.call(rpca, rpca_call_args)
-    }, error = function(e) {
-      warning(sprintf("rpca::rpca failed for run %s: %s", run_name, e$message))
-      rpca_res_r <<- NULL
-    })
+  }
 
-    if (is.null(rpca_res_r) || is.null(rpca_res_r$L)) {
-      warning(sprintf("Robust PCA failed to produce L for run %s (or rpca_res_r is NULL).", run_name))
-      V_list[[run_name]] <- NULL
-      glitch_ratios_per_run[run_name] <- NA
-      next
-    }
-    
-    # As per proposal addendum: Vr <- rp$U (where rp = rpca(Er_t, ...))
-    # This was based on a generic rpca call. The rpca package might return L and S,
-    # and we need to SVD L to get the voxel-space components (U of L if L is Voxels x Time_r).
-    # If L_r_t = rpca_res_r$L (Voxels x Time_r), then its left singular vectors are V_r.
-    L_r_t <- rpca_res_r$L # Voxels x Time_r
-    
-    if (is.null(L_r_t) || min(dim(L_r_t)) == 0 || sum(abs(L_r_t)) < 1e-9) {
-        warning(sprintf("RPCA for run %s yielded an empty or zero L component.", run_name))
-        V_list[[run_name]] <- NULL
-        glitch_ratios_per_run[run_name] <- NA
-        next
-    }
+  merge_res <- .ndx_merge_voxel_components(V_list, current_opts, k_global_target)
+  V_global <- merge_res$V_global
+  V_global_singular_values <- merge_res$singular_values
+  if (is.null(V_global)) return(NULL)
+  k_actual_global_components <- ncol(V_global)
 
-    # Perform SVD on L_r_t to get V_r (left singular vectors of L_r_t)
-    # k_this_run is the target number of components from this L_r_t
-    svd_L_r_t <- NULL
-    k_eff_svd_L <- min(k_this_run, nrow(L_r_t), ncol(L_r_t))
-    if (k_eff_svd_L < k_this_run) {
-        message(sprintf("  Run %s: Effective k for SVD of L_r_t (%d) is less than k_this_run (%d) due to matrix dimensions.", 
-                        run_name, k_eff_svd_L, k_this_run))
-    }
-    
-    tryCatch({
-        # nu = k_this_run means we want up to k_this_run left singular vectors
-        svd_L_r_t <- svd(L_r_t, nu = k_eff_svd_L, nv = 0) 
-    }, error = function(e) {
-        warning(sprintf("SVD on L_r_t for run %s failed: %s", run_name, e$message))
-        svd_L_r_t <<- NULL
-    })
-    
-    if (is.null(svd_L_r_t) || is.null(svd_L_r_t$u) || ncol(svd_L_r_t$u) == 0) {
-      warning(sprintf("SVD of L_r_t for run %s yielded no U components for V_r.", run_name))
-      V_list[[run_name]] <- NULL
-      glitch_ratios_per_run[run_name] <- NA
-      next
-    }
-    V_r <- svd_L_r_t$u # Voxels x (up to) k_this_run
-    
-    # The original proposal note Vr <- rp$U might refer to an rpca implementation where $U 
-    # directly gives the left singular vectors of L if L is the primary low-rank matrix of interest.
-    # With rpca::rpca, we get L and S, then SVD L.
-    
-    if (is.null(V_r) || ncol(V_r) == 0) {
-        warning(sprintf("RPCA for run %s yielded no voxel-space components (V_r is NULL or empty).", run_name))
-        V_list[[run_name]] <- NULL
-        glitch_ratios_per_run[run_name] <- NA
-        next
-    }
-    
-    V_list[[run_name]] <- V_r
-    
-    # Glitch ratio for this run
-    S_r_t <- rpca_res_r$S
-    L_r_t <- rpca_res_r$L
-    energy_S_r <- sum(S_r_t^2)
-    energy_L_r <- sum(L_r_t^2)
-    if (energy_L_r > 1e-9) {
-      glitch_ratios_per_run[run_name] <- energy_S_r / energy_L_r
-    } else {
-      glitch_ratios_per_run[run_name] <- NA
-    }
-
-    # Spike TR mask for this run using median |S| across voxels
-    if (!is.null(S_r_t) && length(S_r_t) > 0 && sum(abs(S_r_t), na.rm = TRUE) > 1e-9) {
-      # Only update if S_r_t is valid and non-zero
-      if (sum(abs(S_r_t), na.rm = TRUE) < 1e-9) {
-        # This condition is a bit redundant due to the outer if, but safe
-        # spike_TR_mask_run <- rep(FALSE, ncol(S_r_t)) # ncol(S_r_t) is Time_r
-        # per_run_spike_TR_masks[[run_name]] <- as.logical(spike_TR_mask_run) # Stays FALSE
-      } else {
-        s_t_star_run <- apply(abs(S_r_t), 2, stats::median, na.rm = TRUE)
-        mad_s_t_star <- stats::mad(s_t_star_run, constant = 1, na.rm = TRUE)
-        if (!is.finite(mad_s_t_star) || mad_s_t_star < 1e-9) {
-          thresh_val <- stats::quantile(s_t_star_run,
-                                        probs = current_opts$rpca_spike_percentile_thresh,
-                                        na.rm = TRUE)
-        } else {
-          thresh_val <- median(s_t_star_run, na.rm = TRUE) +
-            current_opts$rpca_spike_mad_thresh * mad_s_t_star
-        }
-        spike_TR_mask_run <- s_t_star_run > thresh_val
-        if (length(spike_TR_mask_run) == nrow(Er)) { # Ensure correct length
-             per_run_spike_TR_masks[[run_name]] <- as.logical(spike_TR_mask_run)
-        } else {
-            warning(sprintf("Run %s: Generated spike_TR_mask_run length (%d) did not match TRs for run (%d). Using all FALSEs.", 
-                            run_name, length(spike_TR_mask_run), nrow(Er)))
-            # per_run_spike_TR_masks[[run_name]] remains rep(FALSE, nrow(Er))
-        }
-      }
-    } # else, it remains the pre-initialized rep(FALSE, nrow(Er))
-
-    # After S_r_t <- rpca_res_r$S and L_r_t <- rpca_res_r$L
-    if (!is.null(S_r_t)) {
-        S_matrix_list_per_run_TpV[[run_name]] <- t(S_r_t) # Transpose S_r_t (Voxels x Time_r) to Time_r x Voxels
-    } else {
-        S_matrix_list_per_run_TpV[[run_name]] <- matrix(0, nrow = nrow(Er), ncol = ncol(Er)) # Placeholder if S is NULL
-    }
-  } # End per-run RPCA loop
-  
-  # Filter out NULLs from V_list (runs that failed RPCA)
-  V_list_valid <- Filter(Negate(is.null), V_list)
-  if (length(V_list_valid) == 0) {
-    warning("RPCA failed for all runs, or no components were extracted. Cannot proceed.")
+  C_components_cat <- .ndx_form_temporal_components(Y_residuals_list[paste0("run_", unique_runs)], V_global)
+  if (is.null(C_components_cat) ||
+      nrow(C_components_cat) != nrow(Y_residuals_cat) ||
+      ncol(C_components_cat) != k_actual_global_components) {
+    warning("Final concatenated C_components matrix dimensions are incorrect or matrix is NULL. Check C_r formation.")
     return(NULL)
   }
-  message(sprintf("Successfully extracted initial voxel components (V_r) from %d runs.", length(V_list_valid)))
 
-  # --- 3. Merge Voxel-Space Components (V_r) to get V_global --- 
-  V_global <- NULL
-  k_actual_global_components <- 0
-
-  if (current_opts$rpca_merge_strategy == "iterative") {
-    message("Using Iterative Grassmann Averaging for V_global...")
-    V_global <- .grassmann_merge_iterative(V_list_valid, k_global_target)
-    if (!is.null(V_global)) {
-      k_actual_global_components <- ncol(V_global)
-    } else {
-      warning("Iterative Grassmann Averaging failed to produce V_global.")
-      return(NULL) # Or fallback to concat_svd if desired as a robust measure?
-    }
-  } else if (current_opts$rpca_merge_strategy == "concat_svd") {
-    message("Using Concatenate & SVD method for V_global...")
-    V_all_concat_list <- Filter(function(x) !is.null(x) && ncol(x) > 0, V_list_valid)
-    if (length(V_all_concat_list) == 0) {
-        warning("No valid V_r components to concatenate for SVD V_global step.")
-        return(NULL)
-    }
-    V_all_concat <- do.call(cbind, V_all_concat_list)
-    
-    if (is.null(V_all_concat) || ncol(V_all_concat) == 0) {
-        warning("Concatenation of V_r components for SVD V_global resulted in an empty matrix.")
-        return(NULL)
-    }
-    
-    message(sprintf("Performing SVD on concatenated V_r matrix (dims: %s) to find V_global (%d components)", 
-                    paste(dim(V_all_concat), collapse="x"), k_global_target))
-    
-    k_for_svd_V_all <- min(k_global_target, ncol(V_all_concat), nrow(V_all_concat)) 
-    if (k_for_svd_V_all <= 0) {
-        warning(sprintf("Cannot perform SVD on concatenated V_r: k_for_svd_V_all (%d) is not positive.", k_for_svd_V_all))
-        return(NULL)
-    }
-    
-    svd_V_all <- NULL
-    tryCatch({
-        svd_V_all <- svd(V_all_concat, nu = k_for_svd_V_all, nv = 0)
-    }, error = function(e){
-        warning(paste("SVD on concatenated V_r components for V_global failed:", e$message))
-        return(NULL)
-    })
-    
-    if(is.null(svd_V_all) || is.null(svd_V_all$u) || ncol(svd_V_all$u) == 0) {
-        warning("SVD on concatenated V_r for V_global failed to produce U vectors.")
-        return(NULL)
-    }
-    V_global <- svd_V_all$u 
-    k_actual_global_components <- ncol(V_global)
-    message(sprintf("  V_global (concat_svd) obtained with %d components.", k_actual_global_components))
-
-    # IF using concat_svd strategy, capture singular values:
-    if (current_opts$rpca_merge_strategy == "concat_svd" && !is.null(svd_V_all)) {
-      V_global_singular_values <- svd_V_all$d
-    } else if (current_opts$rpca_merge_strategy == "iterative" && !is.null(V_global)) {
-      # For iterative, a representative set of singular values would be harder to get simply.
-      # One option: SVD the final V_global (which should be orthonormal) against itself to get values if meaningful,
-      # or acknowledge that direct singular values for adaptation are best from concat_svd method.
-      # For now, leave NULL if iterative, or compute SVD of final V_global if it makes sense.
-      # Placeholder: if needed, svd(V_global)$d - but V_global cols are already principal components.
-      # The singular values needed are from the matrix whose rank is being adapted.
-      # This is usually the L component or the data matrix itself before RPCA.
-      # The current Auto_Adapt_RPCA_Rank in workflow uses SVD of Y_residuals_current (placeholder).
-      # For true adaptation, this function should output singular values from the L components before merging, or from merged V_all_concat.
-      # For now, only populate from concat_svd strategy.
-      if (verbose && current_opts$rpca_merge_strategy == "iterative") {
-          message("Singular values for rank adaptation not directly available from iterative merge strategy in this function.")
-      }
-    }
-  } else {
-    stop(sprintf("Invalid rpca_merge_strategy: '%s'. Choose 'concat_svd' or 'iterative'.", current_opts$rpca_merge_strategy))
-  }
-
-  if (is.null(V_global) || k_actual_global_components == 0) {
-      warning("V_global is NULL or has zero components after merging. Cannot proceed.")
-      return(NULL)
-  }
-
-  # --- 4. Form Run-Specific Low-Rank Nuisance Time Courses (Cr) --- 
-  C_r_list <- list()
-  message("Forming run-specific temporal components C_r...")
-  for (r_idx in seq_along(Y_residuals_list)) {
-    run_name <- names(Y_residuals_list)[r_idx]
-    Er <- Y_residuals_list[[r_idx]] 
-    
-    if (is.null(Er) || nrow(Er) == 0) {
-        # Ensure C_r contributes zero rows but maintains correct ncol for rbind
-        original_run_TRs <- ifelse(is.null(Y_residuals_list[[run_name]]), 0, nrow(Y_residuals_list[[run_name]]))
-        C_r_list[[run_name]] <- matrix(0, nrow = original_run_TRs, ncol = k_actual_global_components) 
-        next
-    }
-    
-    C_r <- Er %*% V_global 
-    C_r_list[[run_name]] <- C_r
-  }
-  
-  C_components_cat <- do.call(rbind, C_r_list[paste0("run_", unique_runs)])
-  
-  if (is.null(C_components_cat) || nrow(C_components_cat) != nrow(Y_residuals_cat) || ncol(C_components_cat) != k_actual_global_components) {
-      warning("Final concatenated C_components matrix dimensions are incorrect or matrix is NULL. Check C_r formation.")
-      return(NULL)
-  }
-  
-  # --- Concatenate S_matrix per run ---
   S_matrix_cat <- do.call(rbind, S_matrix_list_per_run_TpV[paste0("run_", unique_runs)])
-  if (is.null(S_matrix_cat) || nrow(S_matrix_cat) != nrow(Y_residuals_cat) || ncol(S_matrix_cat) != ncol(Y_residuals_cat)) {
-      warning("Concatenated S_matrix dimensions are incorrect or matrix is NULL. Returning NULL for S_matrix.")
-      S_matrix_cat <- NULL # Ensure it's NULL if problematic
+  if (is.null(S_matrix_cat) ||
+      nrow(S_matrix_cat) != nrow(Y_residuals_cat) ||
+      ncol(S_matrix_cat) != ncol(Y_residuals_cat)) {
+    warning("Concatenated S_matrix dimensions are incorrect or matrix is NULL. Returning NULL for S_matrix.")
+    S_matrix_cat <- NULL
   }
 
-  # Combine spike masks in original run order
   spike_TR_mask <- unlist(per_run_spike_TR_masks[paste0("run_", unique_runs)], use.names = FALSE)
   if (is.null(spike_TR_mask) || length(spike_TR_mask) != nrow(Y_residuals_cat)) {
-    warning(sprintf("Global spike_TR_mask length (%d) mismatch with total timepoints (%d). Defaulting to all FALSE.", 
+    warning(sprintf("Global spike_TR_mask length (%d) mismatch with total timepoints (%d). Defaulting to all FALSE.",
                     length(spike_TR_mask %||% 0), nrow(Y_residuals_cat)))
     spike_TR_mask <- rep(FALSE, nrow(Y_residuals_cat))
   } else {
@@ -476,8 +195,7 @@ ndx_rpca_temporal_components_multirun <- function(Y_residuals_cat, run_idx,
   return(list(C_components = C_components_cat,
               spike_TR_mask = spike_TR_mask,
               S_matrix_cat = S_matrix_cat,
-              V_global_singular_values = V_global_singular_values
-              ))
+              V_global_singular_values = V_global_singular_values))
 }
 
 #' Iterative Grassmann Averaging of Voxel-Space Components

--- a/R/ndx_rpca_helpers.R
+++ b/R/ndx_rpca_helpers.R
@@ -1,0 +1,243 @@
+#' Run RPCA for a Single Run
+#'
+#' Internal helper used by `ndx_rpca_temporal_components_multirun`.
+#' Performs RPCA on a single run's residual matrix and extracts the
+#' voxel-space components.
+#'
+#' @param Er Numeric matrix of residuals for one run (Time x Voxels).
+#' @param run_name Character run label used in messages.
+#' @param opts List of options controlling the RPCA step.
+#' @return List with elements `V_r`, `S_r_t`, `spike_mask` and `glitch_ratio`.
+#' @keywords internal
+.ndx_rpca_single_run <- function(Er, run_name, opts) {
+  spike_mask <- if (nrow(Er) > 0) rep(FALSE, nrow(Er)) else logical(0)
+
+  if (nrow(Er) == 0 || ncol(Er) == 0) {
+    warning(sprintf("Residuals for run %s are empty (dims: %s). Skipping RPCA for this run.",
+                    run_name, paste(dim(Er), collapse = "x")))
+    return(list(V_r = NULL, S_r_t = NULL, spike_mask = spike_mask, glitch_ratio = NA))
+  }
+
+  Er_t <- t(Er)
+  lambda_r <- if (opts$rpca_lambda_auto) {
+    1 / sqrt(max(dim(Er_t)))
+  } else {
+    if (is.null(opts$rpca_lambda_fixed))
+      stop("rpca_lambda_fixed must be provided if rpca_lambda_auto is FALSE.")
+    opts$rpca_lambda_fixed
+  }
+
+  rpca_call_args <- list(
+    M = Er_t,
+    lambda = lambda_r,
+    term.delta = opts$rpca_term_delta,
+    max.iter = opts$rpca_max_iter,
+    trace = opts$rpca_trace
+  )
+
+  if (!is.null(opts$rpca_mu)) {
+    rpca_call_args$mu <- opts$rpca_mu
+    message(sprintf("  Run %s: Using user-specified mu = %f for rpca.", run_name, opts$rpca_mu))
+  } else {
+    temp_mu_for_logging <- if (sum(abs(Er_t)) > 1e-9) {
+      prod(dim(Er_t)) / (4 * sum(abs(Er_t)))
+    } else {
+      1.0
+    }
+    message(sprintf(
+      "  Run %s: rpca_mu is NULL, rpca::rpca will use its internal default mu (approx for logging: %.2e).",
+      run_name, temp_mu_for_logging
+    ))
+  }
+
+  k_this_run <- min(opts$k_per_run_target, min(dim(Er_t)))
+  if (k_this_run <= 0) {
+    warning(sprintf(
+      "Cannot perform RPCA for run %s: k_this_run (%d) is not positive after adjustment. Skipping.",
+      run_name, k_this_run
+    ))
+    return(list(V_r = NULL, S_r_t = NULL, spike_mask = spike_mask, glitch_ratio = NA))
+  }
+
+  message(sprintf(
+    "  Processing run %s (data: %d voxels x %d TRs, target k: %d, lambda: %.2e)",
+    run_name, nrow(Er_t), ncol(Er_t), k_this_run, lambda_r
+  ))
+
+  rpca_res_r <- NULL
+  tryCatch({
+    rpca_res_r <- do.call(rpca, rpca_call_args)
+  }, error = function(e) {
+    warning(sprintf("rpca::rpca failed for run %s: %s", run_name, e$message))
+    rpca_res_r <<- NULL
+  })
+
+  if (is.null(rpca_res_r) || is.null(rpca_res_r$L)) {
+    warning(sprintf("Robust PCA failed to produce L for run %s (or rpca_res_r is NULL).", run_name))
+    return(list(V_r = NULL, S_r_t = NULL, spike_mask = spike_mask, glitch_ratio = NA))
+  }
+
+  L_r_t <- rpca_res_r$L
+  if (is.null(L_r_t) || min(dim(L_r_t)) == 0 || sum(abs(L_r_t)) < 1e-9) {
+    warning(sprintf("RPCA for run %s yielded an empty or zero L component.", run_name))
+    return(list(V_r = NULL, S_r_t = rpca_res_r$S, spike_mask = spike_mask, glitch_ratio = NA))
+  }
+
+  k_eff_svd_L <- min(k_this_run, nrow(L_r_t), ncol(L_r_t))
+  if (k_eff_svd_L < k_this_run) {
+    message(sprintf(
+      "  Run %s: Effective k for SVD of L_r_t (%d) is less than k_this_run (%d) due to matrix dimensions.",
+      run_name, k_eff_svd_L, k_this_run
+    ))
+  }
+
+  svd_L_r_t <- NULL
+  tryCatch({
+    svd_L_r_t <- svd(L_r_t, nu = k_eff_svd_L, nv = 0)
+  }, error = function(e) {
+    warning(sprintf("SVD on L_r_t for run %s failed: %s", run_name, e$message))
+    svd_L_r_t <<- NULL
+  })
+
+  if (is.null(svd_L_r_t) || is.null(svd_L_r_t$u) || ncol(svd_L_r_t$u) == 0) {
+    warning(sprintf("SVD of L_r_t for run %s yielded no U components for V_r.", run_name))
+    return(list(V_r = NULL, S_r_t = rpca_res_r$S, spike_mask = spike_mask, glitch_ratio = NA))
+  }
+
+  V_r <- svd_L_r_t$u
+  S_r_t <- rpca_res_r$S
+
+  glitch_ratio <- NA
+  if (!is.null(S_r_t) && !is.null(L_r_t)) {
+    energy_S_r <- sum(S_r_t^2)
+    energy_L_r <- sum(L_r_t^2)
+    if (energy_L_r > 1e-9) glitch_ratio <- energy_S_r / energy_L_r
+  }
+
+  if (!is.null(S_r_t) && length(S_r_t) > 0 && sum(abs(S_r_t), na.rm = TRUE) > 1e-9) {
+    s_t_star_run <- apply(abs(S_r_t), 2, stats::median, na.rm = TRUE)
+    mad_s_t_star <- stats::mad(s_t_star_run, constant = 1, na.rm = TRUE)
+    if (!is.finite(mad_s_t_star) || mad_s_t_star < 1e-9) {
+      thresh_val <- stats::quantile(s_t_star_run,
+                                    probs = opts$rpca_spike_percentile_thresh,
+                                    na.rm = TRUE)
+    } else {
+      thresh_val <- median(s_t_star_run, na.rm = TRUE) +
+        opts$rpca_spike_mad_thresh * mad_s_t_star
+    }
+    spike_tmp <- s_t_star_run > thresh_val
+    if (length(spike_tmp) == nrow(Er)) {
+      spike_mask <- as.logical(spike_tmp)
+    } else {
+      warning(sprintf(
+        "Run %s: Generated spike_TR_mask_run length (%d) did not match TRs for run (%d). Using all FALSEs.",
+        run_name, length(spike_tmp), nrow(Er)
+      ))
+      spike_mask <- rep(FALSE, nrow(Er))
+    }
+  }
+
+  list(V_r = V_r, S_r_t = S_r_t, spike_mask = spike_mask, glitch_ratio = glitch_ratio)
+}
+
+#' Merge Voxel Components Across Runs
+#'
+#' Handles the choice between `concat_svd` and `iterative` strategies when
+#' forming the global voxel-space basis.
+#'
+#' @param V_list List of per-run V_r matrices (may contain `NULL`).
+#' @param opts Options list controlling the merge strategy.
+#' @param k_target Desired number of global components.
+#' @return List with `V_global` and `singular_values`.
+#' @keywords internal
+.ndx_merge_voxel_components <- function(V_list, opts, k_target) {
+  V_list_valid <- Filter(Negate(is.null), V_list)
+  if (length(V_list_valid) == 0) {
+    warning("RPCA failed for all runs, or no components were extracted. Cannot proceed.")
+    return(list(V_global = NULL, singular_values = NULL))
+  }
+  message(sprintf("Successfully extracted initial voxel components (V_r) from %d runs.",
+                  length(V_list_valid)))
+
+  V_global <- NULL
+  V_global_singular_values <- NULL
+
+  if (opts$rpca_merge_strategy == "iterative") {
+    message("Using Iterative Grassmann Averaging for V_global...")
+    V_global <- .grassmann_merge_iterative(V_list_valid, k_target)
+    if (is.null(V_global)) {
+      warning("Iterative Grassmann Averaging failed to produce V_global.")
+      return(list(V_global = NULL, singular_values = NULL))
+    }
+  } else if (opts$rpca_merge_strategy == "concat_svd") {
+    message("Using Concatenate & SVD method for V_global...")
+    V_all_concat_list <- Filter(function(x) !is.null(x) && ncol(x) > 0, V_list_valid)
+    if (length(V_all_concat_list) == 0) {
+      warning("No valid V_r components to concatenate for SVD V_global step.")
+      return(list(V_global = NULL, singular_values = NULL))
+    }
+    V_all_concat <- do.call(cbind, V_all_concat_list)
+    if (is.null(V_all_concat) || ncol(V_all_concat) == 0) {
+      warning("Concatenation of V_r components for SVD V_global resulted in an empty matrix.")
+      return(list(V_global = NULL, singular_values = NULL))
+    }
+    message(sprintf(
+      "Performing SVD on concatenated V_r matrix (dims: %s) to find V_global (%d components)",
+      paste(dim(V_all_concat), collapse = "x"), k_target
+    ))
+    k_for_svd_V_all <- min(k_target, ncol(V_all_concat), nrow(V_all_concat))
+    if (k_for_svd_V_all <= 0) {
+      warning(sprintf(
+        "Cannot perform SVD on concatenated V_r: k_for_svd_V_all (%d) is not positive.",
+        k_for_svd_V_all
+      ))
+      return(list(V_global = NULL, singular_values = NULL))
+    }
+    svd_V_all <- NULL
+    tryCatch({
+      svd_V_all <- svd(V_all_concat, nu = k_for_svd_V_all, nv = 0)
+    }, error = function(e) {
+      warning(paste("SVD on concatenated V_r components for V_global failed:", e$message))
+      svd_V_all <<- NULL
+    })
+    if (is.null(svd_V_all) || is.null(svd_V_all$u) || ncol(svd_V_all$u) == 0) {
+      warning("SVD on concatenated V_r for V_global failed to produce U vectors.")
+      return(list(V_global = NULL, singular_values = NULL))
+    }
+    V_global <- svd_V_all$u
+    V_global_singular_values <- svd_V_all$d
+    message(sprintf("  V_global (concat_svd) obtained with %d components.", ncol(V_global)))
+  } else {
+    stop(sprintf("Invalid rpca_merge_strategy: '%s'. Choose 'concat_svd' or 'iterative'.",
+                 opts$rpca_merge_strategy))
+  }
+
+  if (is.null(V_global) || ncol(V_global) == 0) {
+    warning("V_global is NULL or has zero components after merging. Cannot proceed.")
+    return(list(V_global = NULL, singular_values = NULL))
+  }
+
+  list(V_global = V_global, singular_values = V_global_singular_values)
+}
+
+#' Form Temporal Components From Residuals
+#'
+#' Multiplies each run's residuals by the global voxel-space basis and
+#' concatenates the results.
+#'
+#' @param residuals_list List of residual matrices (Time x Voxels) for each run.
+#' @param V_global Voxel-space basis matrix returned from merging.
+#' @return Matrix of concatenated temporal components.
+#' @keywords internal
+.ndx_form_temporal_components <- function(residuals_list, V_global) {
+  message("Forming run-specific temporal components C_r...")
+  C_r_list <- lapply(residuals_list, function(E) {
+    if (is.null(E) || nrow(E) == 0) {
+      matrix(0, nrow = nrow(E), ncol = ncol(V_global))
+    } else {
+      E %*% V_global
+    }
+  })
+  do.call(rbind, C_r_list)
+}
+


### PR DESCRIPTION
## Summary
- break up `ndx_rpca_temporal_components_multirun` by adding three internal helpers
- implement `.ndx_rpca_single_run` to process a single run
- implement `.ndx_merge_voxel_components` to build `V_global`
- implement `.ndx_form_temporal_components` for run-wise temporal components
- simplify `ndx_rpca_temporal_components_multirun` using the new helpers

## Testing
- `Rscript run_tests.R` *(fails: Rscript not found)*