### PR TITLE
Fix unmatched brace in spectral function

### DIFF
--- a/R/ndx_spectral.R
+++ b/R/ndx_spectral.R
@@ -77,6 +77,8 @@ ndx_spectral_sines <- function(mean_residual_for_spectrum, TR,
     warning("mean_residual_for_spectrum contains non-finite values.")
     return(.empty_spec_matrix(length(mean_residual_for_spectrum)))
 
+  }
+
   default_n_sine_candidates <- 6
   if (!is.numeric(n_sine_candidates) || length(n_sine_candidates) != 1 ||
       n_sine_candidates <= 0) {


### PR DESCRIPTION
## Summary
- ensure ndx_spectral_sines closes the non-finite check properly

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`