### PR TITLE
Move val_or_na helper into utilities

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,7 @@
 export(Auto_Adapt_RPCA_Rank)
 export(NDX_Process_Subject)
 export(ndx_default_user_options)
+export(ndx_val_or_na)
 export(merge_lists)
 export(`%||%`)
 export(Select_Significant_Spectral_Regressors)

--- a/R/ndx_diagnostics.R
+++ b/R/ndx_diagnostics.R
@@ -430,33 +430,31 @@ ndx_generate_json_certificate <- function(workflow_output,
 
   last_diag <- workflow_output$diagnostics_per_pass[[workflow_output$num_passes_completed]]
 
-  val_or_na <- function(x) if (is.null(x)) NA else x
-
   verdict_stats <- ndx_annihilation_verdict_stats(workflow_output)
 
   cert_list <- list(
     ndx_version = as.character(utils::packageVersion("ndx")),
-    final_DES = val_or_na(last_diag$DES),
-    ljung_box_p = val_or_na(last_diag$ljung_box_p),
-    var_ratio = val_or_na(verdict_stats$var_ratio),
-    verdict = val_or_na(verdict_stats$verdict),
-    passes_converged = val_or_na(workflow_output$num_passes_completed),
-    final_rho_noise_projection = val_or_na(last_diag$rho_noise_projection),
-    final_beta_stability = val_or_na(tail(calculate_beta_stability(workflow_output$beta_history_per_pass),1)),
-    ljung_box_p_median = val_or_na(median(compute_ljung_box_pvalues(workflow_output$Y_residuals_final_unwhitened), na.rm=TRUE)),
+    final_DES = ndx_val_or_na(last_diag$DES),
+    ljung_box_p = ndx_val_or_na(last_diag$ljung_box_p),
+    var_ratio = ndx_val_or_na(verdict_stats$var_ratio),
+    verdict = ndx_val_or_na(verdict_stats$verdict),
+    passes_converged = ndx_val_or_na(workflow_output$num_passes_completed),
+    final_rho_noise_projection = ndx_val_or_na(last_diag$rho_noise_projection),
+    final_beta_stability = ndx_val_or_na(tail(calculate_beta_stability(workflow_output$beta_history_per_pass),1)),
+    ljung_box_p_median = ndx_val_or_na(median(compute_ljung_box_pvalues(workflow_output$Y_residuals_final_unwhitened), na.rm=TRUE)),
     final_adaptive_hyperparameters = list(
-      k_rpca_global = val_or_na(last_diag$k_rpca_global),
-      num_hrf_clusters = val_or_na(last_diag$num_hrf_clusters),
-      num_spectral_sines = val_or_na(last_diag$num_spectral_sines),
-      lambda_parallel_noise = val_or_na(last_diag$lambda_parallel_noise),
-      lambda_perp_signal = val_or_na(last_diag$lambda_perp_signal)
+      k_rpca_global = ndx_val_or_na(last_diag$k_rpca_global),
+      num_hrf_clusters = ndx_val_or_na(last_diag$num_hrf_clusters),
+      num_spectral_sines = ndx_val_or_na(last_diag$num_spectral_sines),
+      lambda_parallel_noise = ndx_val_or_na(last_diag$lambda_parallel_noise),
+      lambda_perp_signal = ndx_val_or_na(last_diag$lambda_perp_signal)
     ),
     timestamp = as.character(Sys.time()),
     workflow_hash = digest::digest(list(
       diagnostics = workflow_output$diagnostics_per_pass,
       settings = list(
         num_passes_completed = workflow_output$num_passes_completed,
-        annihilation_mode_active = val_or_na(workflow_output$annihilation_mode_active)
+        annihilation_mode_active = ndx_val_or_na(workflow_output$annihilation_mode_active)
       )
     ))
   )

--- a/R/ndx_utils.R
+++ b/R/ndx_utils.R
@@ -13,6 +13,19 @@ NULL
 
 # Placeholder for actual utility functions
 
+#' Return `NA` if Value is `NULL`
+#'
+#' Simple helper that returns `NA` when the input is `NULL`, otherwise the
+#' input value unchanged.
+#'
+#' @param x An object that might be `NULL`.
+#' @return `NA` if `x` is `NULL`, otherwise `x`.
+#' @keywords internal
+#' @export
+ndx_val_or_na <- function(x) {
+  if (is.null(x)) NA else x
+}
+
 #' Calculate OLS residuals using lm.fit
 #'
 #' @param Y Dependent variable matrix (timepoints x variables/voxels).

--- a/tests/testthat/test-val_or_na.R
+++ b/tests/testthat/test-val_or_na.R
@@ -1,0 +1,11 @@
+context("ndx_val_or_na")
+
+test_that("returns NA for NULL", {
+  expect_true(is.na(ndx_val_or_na(NULL)))
+})
+
+test_that("returns value when not NULL", {
+  expect_equal(ndx_val_or_na(5), 5)
+  expect_equal(ndx_val_or_na("a"), "a")
+})
+


### PR DESCRIPTION
## Summary
- provide `ndx_val_or_na` in `ndx_utils.R`
- export the helper in NAMESPACE
- use `ndx_val_or_na` in `ndx_generate_json_certificate`
- test the helper function

## Testing
- `Rscript run_tests.R` *(fails: command not found)*