### PR TITLE
Refactor spectral helper functions

### DIFF
--- a/R/ndx_spectral.R
+++ b/R/ndx_spectral.R
@@ -63,19 +63,89 @@ ndx_spectral_sines <- function(mean_residual_for_spectrum, TR,
                                selection_criterion = "BIC",
                                selection_delta_threshold = 2,
                                verbose = FALSE) {
+  val <- .validate_spectral_inputs(mean_residual_for_spectrum, TR,
+                                   n_sine_candidates,
+                                   selection_delta_threshold)
+  if (!is.null(val$error)) return(val$error)
+  mean_residual_for_spectrum <- val$vec
+  n_sine_candidates <- val$n_sine_candidates
+  selection_delta_threshold <- val$selection_delta_threshold
 
-  if (!is.numeric(mean_residual_for_spectrum) || length(mean_residual_for_spectrum) == 0) {
+  adj <- .adjust_mtm_params(k_tapers, nw,
+                            length(mean_residual_for_spectrum), verbose)
+  if (!is.null(adj$error)) return(adj$error)
+  k_tapers <- adj$k_tapers
+  nw <- adj$nw
+
+  mt_res <- .estimate_spectrum(mean_residual_for_spectrum, TR, k_tapers, nw)
+  if (is.null(mt_res)) {
+    return(.empty_spec_matrix(length(mean_residual_for_spectrum)))
+  }
+
+  freqs_hz <- .find_spectral_peaks(mt_res, TR, nyquist_guard_factor,
+                                   n_sine_candidates, verbose)
+  if (length(freqs_hz) == 0) {
+    if (verbose) message("No peaks selected after uniqueness filter to generate sine/cosine pairs.")
+    return(.empty_spec_matrix(length(mean_residual_for_spectrum)))
+  }
+
+  U_spectral_sines <- .build_sine_regressors(freqs_hz,
+                                             length(mean_residual_for_spectrum),
+                                             TR)
+
+  if (verbose) {
+    message(sprintf("Generated %d sine/cosine pairs from %d spectral peaks.",
+                    ncol(U_spectral_sines) / 2, length(freqs_hz)))
+  }
+
+  selected_regressors <- Select_Significant_Spectral_Regressors(
+    y = mean_residual_for_spectrum,
+    U_candidates = U_spectral_sines,
+    criterion = selection_criterion,
+    delta_threshold = selection_delta_threshold,
+    verbose = verbose
+  )
+
+  return(selected_regressors)
+}
+
+#' Create an empty matrix for spectral regressors
+#'
+#' @keywords internal
+.empty_spec_matrix <- function(n_rows) {
+  res <- matrix(numeric(0), nrow = n_rows, ncol = 0,
+                dimnames = list(NULL, character(0)))
+  attr(res, "freq_hz") <- numeric(0)
+  attr(res, "freq_rad_s") <- numeric(0)
+  attr(res, "selected_pair_indices") <- integer(0)
+  res
+}
+
+#' Validate and preprocess inputs for ndx_spectral_sines
+#'
+#' Returns a list containing a centered time series, the (possibly adjusted)
+#' `n_sine_candidates`, `selection_delta_threshold`, and an `error` element. If
+#' validation fails the `error` element contains the object that should be
+#' returned by `ndx_spectral_sines`.
+#'
+#' @keywords internal
+.validate_spectral_inputs <- function(mean_residual_for_spectrum, TR,
+                                      n_sine_candidates,
+                                      selection_delta_threshold) {
+  if (!is.numeric(mean_residual_for_spectrum) ||
+      length(mean_residual_for_spectrum) == 0) {
     warning("mean_residual_for_spectrum must be a non-empty numeric vector.")
-    return(NULL)
+    return(list(error = NULL))
   }
   if (!is.numeric(TR) || TR <= 0) {
     warning("TR must be a positive numeric value.")
-    return(NULL)
+    return(list(error = NULL))
   }
 
   if (!all(is.finite(mean_residual_for_spectrum))) {
     warning("mean_residual_for_spectrum contains non-finite values.")
-    return(.empty_spec_matrix(length(mean_residual_for_spectrum)))
+    return(list(error = .empty_spec_matrix(length(mean_residual_for_spectrum))))
+  }
 
   default_n_sine_candidates <- 6
   if (!is.numeric(n_sine_candidates) || length(n_sine_candidates) != 1 ||
@@ -96,190 +166,212 @@ ndx_spectral_sines <- function(mean_residual_for_spectrum, TR,
     selection_delta_threshold <- default_selection_delta_threshold
   }
 
-  # De-mean the series (Feedback 2.1)
-  mean_residual_for_spectrum <- base::scale(mean_residual_for_spectrum, center = TRUE, scale = FALSE)[,1]
+  vec <- base::scale(mean_residual_for_spectrum, center = TRUE,
+                     scale = FALSE)[, 1]
 
-  # Adjust nw based on series length first (Feedback 2.3)
+  list(vec = vec,
+       n_sine_candidates = n_sine_candidates,
+       selection_delta_threshold = selection_delta_threshold,
+       error = NULL)
+}
+
+#' Adjust multitaper parameters for series length
+#'
+#' Ensures `nw` and `k_tapers` are compatible with the data length. If the
+#' resulting values are invalid a list with an `error` element is returned.
+#'
+#' @keywords internal
+.adjust_mtm_params <- function(k_tapers, nw, series_length, verbose = FALSE) {
   original_nw <- nw
-  nw <- min(nw, floor((length(mean_residual_for_spectrum)-1)/2))
+  nw <- min(nw, floor((series_length - 1) / 2))
   if (nw < original_nw && verbose) {
-    message(sprintf("  ndx_spectral_sines: nw was reduced from %s to %s to be compatible with series length %d.", 
-                    original_nw, nw, length(mean_residual_for_spectrum)))
+    message(sprintf(
+      "  ndx_spectral_sines: nw was reduced from %s to %s to be compatible with series length %d.",
+      original_nw, nw, series_length))
   }
   if (nw <= 0) {
-      warning(sprintf("nw became %.2f after adjustment. Must be > 0. Aborting spectral step.", nw))
-      return(.empty_spec_matrix(length(mean_residual_for_spectrum)))
+    warning(sprintf(
+      "nw became %.2f after adjustment. Must be > 0. Aborting spectral step.",
+      nw))
+    return(list(error = .empty_spec_matrix(series_length)))
   }
 
-  # Adjust k_tapers (Feedback 2.2 for as.integer)
   original_k_tapers <- k_tapers
-  k_tapers <- as.integer(min(k_tapers, 2 * nw - 1, length(mean_residual_for_spectrum) - 1))
+  k_tapers <- as.integer(min(k_tapers, 2 * nw - 1, series_length - 1))
   if (k_tapers < original_k_tapers && verbose) {
-      message(sprintf("  ndx_spectral_sines: k_tapers reduced from %d to %d based on nw (%.2f) and series length (%d).",
-                      original_k_tapers, k_tapers, nw, length(mean_residual_for_spectrum)))
+    message(sprintf(
+      "  ndx_spectral_sines: k_tapers reduced from %d to %d based on nw (%.2f) and series length (%d).",
+      original_k_tapers, k_tapers, nw, series_length))
   }
 
   if (k_tapers < 1) {
-    warning(sprintf("k_tapers became %d after adjustment (nw=%.2f, series_length=%d). Must be >= 1. Aborting spectral step.",
-                    k_tapers, nw, length(mean_residual_for_spectrum)))
-    return(.empty_spec_matrix(length(mean_residual_for_spectrum)))
+    warning(sprintf(
+      "k_tapers became %d after adjustment (nw=%.2f, series_length=%d). Must be >= 1. Aborting spectral step.",
+      k_tapers, nw, series_length))
+    return(list(error = .empty_spec_matrix(series_length)))
   }
 
+  list(k_tapers = k_tapers, nw = nw, error = NULL)
+}
+
+#' Run multitaper spectrum estimation
+#'
+#' Wrapper around `multitaper::spec.mtm`. Returns `NULL` when estimation fails.
+#'
+#' @keywords internal
+.estimate_spectrum <- function(ts, TR, k_tapers, nw) {
   mt_res <- NULL
   tryCatch({
-    mt_res <- multitaper::spec.mtm(mean_residual_for_spectrum,
-                                   k       = k_tapers,
-                                   nw      = nw,
-                                   deltat  = TR,
+    mt_res <- multitaper::spec.mtm(ts,
+                                   k = k_tapers,
+                                   nw = nw,
+                                   deltat = TR,
                                    jackknife = FALSE,
                                    returnInternals = FALSE,
-                                   plot    = FALSE)
+                                   plot = FALSE)
   }, error = function(e) {
     warning(paste("multitaper::spec.mtm failed:", e$message))
     assign("mt_res", NULL, envir = parent.env(environment()))
   })
 
-  if (is.null(mt_res) || is.null(mt_res$spec) || is.null(mt_res$freq) || length(mt_res$spec) == 0) {
+  if (is.null(mt_res) || is.null(mt_res$spec) || is.null(mt_res$freq) ||
+      length(mt_res$spec) == 0) {
     warning("Spectrum estimation via spec.mtm did not yield valid spec or freq.")
-    return(.empty_spec_matrix(length(mean_residual_for_spectrum)))
+    return(NULL)
   }
+  mt_res
+}
 
-  nyquist_freq  <- 1 / (2 * TR)
-  # Ensure guard factor is within reasonable bounds
-  guard_factor <- max(0, min(1, nyquist_guard_factor)) 
-  
+#' Identify prominent spectral peaks
+#'
+#' Searches for peaks below a guarded Nyquist frequency and returns the selected
+#' frequencies in Hz.
+#'
+#' @keywords internal
+.find_spectral_peaks <- function(mt_res, TR, nyquist_guard_factor,
+                                 n_sine_candidates, verbose = FALSE) {
+  nyquist_freq <- 1 / (2 * TR)
+  guard_factor <- max(0, min(1, nyquist_guard_factor))
+
   freq_upper_bound <- guard_factor * nyquist_freq
-  keep_indices <- mt_res$freq > 0 & mt_res$freq <= freq_upper_bound # Exclude DC, respect guard
+  keep_indices <- mt_res$freq > 0 & mt_res$freq <= freq_upper_bound
 
   if (sum(keep_indices) == 0) {
     warning("No frequencies to search for peaks after applying guard factor and excluding DC.")
-    return(.empty_spec_matrix(length(mean_residual_for_spectrum)))
+    return(numeric(0))
   }
 
   spec_to_search <- mt_res$spec[keep_indices]
   freq_to_search <- mt_res$freq[keep_indices]
 
   if (verbose) {
-    message(sprintf("  Spectral search range: %.4f Hz to %.4f Hz (%d points)", min(freq_to_search), max(freq_to_search), length(freq_to_search)))
-    message(sprintf("  Summary of spec_to_search: Min=%.2e, Med=%.2e, Mean=%.2e, Max=%.2e, SD=%.2e", 
-                    min(spec_to_search), median(spec_to_search), mean(spec_to_search), max(spec_to_search), sd(spec_to_search)))
+    message(sprintf(
+      "  Spectral search range: %.4f Hz to %.4f Hz (%d points)",
+      min(freq_to_search), max(freq_to_search), length(freq_to_search)))
+    message(sprintf(
+      "  Summary of spec_to_search: Min=%.2e, Med=%.2e, Mean=%.2e, Max=%.2e, SD=%.2e",
+      min(spec_to_search), median(spec_to_search), mean(spec_to_search),
+      max(spec_to_search), sd(spec_to_search)))
   }
 
-  peak_info_all <- pracma::findpeaks(spec_to_search, nups = 1, ndowns = 1, sortstr = TRUE)
-  if (verbose && !is.null(peak_info_all)) message(sprintf("  findpeaks found %d initial peaks. Top peak amplitude: %.2e at index %d", nrow(peak_info_all), if(nrow(peak_info_all)>0) peak_info_all[1,1] else NA, if(nrow(peak_info_all)>0) peak_info_all[1,2] else NA))
-  else if (verbose && is.null(peak_info_all)) message("  findpeaks returned NULL.")
+  peak_info_all <- pracma::findpeaks(spec_to_search, nups = 1, ndowns = 1,
+                                     sortstr = TRUE)
+  if (verbose && !is.null(peak_info_all)) {
+    message(sprintf(
+      "  findpeaks found %d initial peaks. Top peak amplitude: %.2e at index %d",
+      nrow(peak_info_all),
+      if (nrow(peak_info_all) > 0) peak_info_all[1, 1] else NA,
+      if (nrow(peak_info_all) > 0) peak_info_all[1, 2] else NA))
+  } else if (verbose && is.null(peak_info_all)) {
+    message("  findpeaks returned NULL.")
+  }
 
   if (is.null(peak_info_all) || nrow(peak_info_all) == 0) {
     if (verbose) message("No initial peaks found in the spectrum by pracma::findpeaks.")
-    return(.empty_spec_matrix(length(mean_residual_for_spectrum)))
+    return(numeric(0))
   }
-  
-  # Peak prominence filter
-  prom_thresh <- median(spec_to_search, na.rm = TRUE) + 3 * mad(spec_to_search, na.rm = TRUE)
+
+  prom_thresh <- median(spec_to_search, na.rm = TRUE) +
+    3 * mad(spec_to_search, na.rm = TRUE)
   if (verbose) message(sprintf("  Prominence threshold for peaks: %.2e", prom_thresh))
-  
-  # Ensure threshold is a single finite number, if mad is 0 or spec_to_search is flat, this could be tricky
+
   if (!is.finite(prom_thresh)) {
-    prom_thresh <- -Inf # Effectively disable filter if MAD is zero or issues
+    prom_thresh <- -Inf
     warning("Prominence threshold for peak picking was not finite (e.g. MAD was zero). Filter effectively disabled.")
   }
-  
-  # Keep peaks with amplitude (col 1) > prom_thresh
-  # peak_info_all is already sorted by amplitude (col 1) due to sortstr=TRUE
-  peak_info <- peak_info_all[peak_info_all[,1] > prom_thresh, , drop = FALSE]
-  if (verbose && !is.null(peak_info)) message(sprintf("  After prominence filter, %d peaks remain. Top peak amplitude: %.2e", nrow(peak_info), if(nrow(peak_info)>0) peak_info[1,1] else NA))
-  else if (verbose && is.null(peak_info)) message("  peak_info is NULL after prominence filter (should be 0-row matrix if no peaks pass).")
+
+  peak_info <- peak_info_all[peak_info_all[, 1] > prom_thresh, , drop = FALSE]
+  if (verbose && !is.null(peak_info)) {
+    message(sprintf(
+      "  After prominence filter, %d peaks remain. Top peak amplitude: %.2e",
+      nrow(peak_info), if (nrow(peak_info) > 0) peak_info[1, 1] else NA))
+  } else if (verbose && is.null(peak_info)) {
+    message("  peak_info is NULL after prominence filter (should be 0-row matrix if no peaks pass).")
+  }
 
   if (is.null(peak_info) || nrow(peak_info) == 0) {
-    if (verbose) message(sprintf("No significant peaks found after prominence filter (threshold: %.4g).", prom_thresh))
-    return(.empty_spec_matrix(length(mean_residual_for_spectrum)))
+    if (verbose) message(sprintf(
+      "No significant peaks found after prominence filter (threshold: %.4g).",
+      prom_thresh))
+    return(numeric(0))
   }
-  
-  # Select top n_sine_candidates peaks based on their amplitude (peak_info already sorted by findpeaks with sortstr=TRUE)
-  num_peaks_to_select <- min(n_sine_candidates, nrow(peak_info))
-  selected_peak_indices_in_searched_spec <- peak_info[1:num_peaks_to_select, 2]
 
-  # Frequencies corresponding to these selected peaks
-  selected_frequencies_hz <- freq_to_search[selected_peak_indices_in_searched_spec]
-  
-  # Apply unique (Feedback 2.4)
+  num_peaks_to_select <- min(n_sine_candidates, nrow(peak_info))
+  sel_idx <- peak_info[1:num_peaks_to_select, 2]
+
+  selected_frequencies_hz <- freq_to_search[sel_idx]
   if (length(selected_frequencies_hz) > 0) {
-    original_selected_freq_count <- length(selected_frequencies_hz)
+    orig_n <- length(selected_frequencies_hz)
     selected_frequencies_hz <- unique(selected_frequencies_hz)
-    if (length(selected_frequencies_hz) < original_selected_freq_count && verbose) {
-        message(sprintf("  Reduced to %d unique peak frequencies from %d for regressor generation.", 
-                        length(selected_frequencies_hz), original_selected_freq_count))
+    if (length(selected_frequencies_hz) < orig_n && verbose) {
+      message(sprintf(
+        "  Reduced to %d unique peak frequencies from %d for regressor generation.",
+        length(selected_frequencies_hz), orig_n))
     }
   }
 
-  if (length(selected_frequencies_hz) == 0) {
-    if (verbose) message("No peaks selected after uniqueness filter to generate sine/cosine pairs.")
-    # Return consistent empty matrix with attributes
-    return(.empty_spec_matrix(length(mean_residual_for_spectrum)))
+  selected_frequencies_hz
+}
+
+#' Build sine and cosine regressors for the given frequencies
+#'
+#' Returns a matrix with sine columns followed by cosine columns. Attributes
+#' `freq_hz` and `freq_rad_s` store the input frequencies.
+#'
+#' @keywords internal
+.build_sine_regressors <- function(freqs_hz, series_length, TR) {
+  if (length(freqs_hz) == 0) {
+    return(.empty_spec_matrix(series_length))
   }
 
-  omega_rad_s <- 2 * pi * selected_frequencies_hz # Convert Hz to radians/sec
-  time_vector_sec <- (seq_along(mean_residual_for_spectrum) - 1) * TR # Time vector in seconds, starting at 0
+  omega_rad_s <- 2 * pi * freqs_hz
+  time_vector_sec <- (seq_len(series_length) - 1) * TR
 
   U_sin_raw <- sapply(omega_rad_s, function(w) sin(w * time_vector_sec))
   U_cos_raw <- sapply(omega_rad_s, function(w) cos(w * time_vector_sec))
-  
-  # Ensure matrix even if only one frequency
+
   if (is.vector(U_sin_raw)) U_sin_raw <- matrix(U_sin_raw, ncol = 1)
   if (is.vector(U_cos_raw)) U_cos_raw <- matrix(U_cos_raw, ncol = 1)
-  
-  # Normalize columns to have unit norm (for exact orthogonality)
-  # center = FALSE because we don't want to de-mean sines/cosines
-  # scale = sqrt(colSums(X^2)) to divide by L2 norm
+
   U_sin <- apply(U_sin_raw, 2, function(col) {
-    norm_val <- sqrt(sum(col^2))
-    if (norm_val > .Machine$double.eps) col / norm_val else col
+    nrm <- sqrt(sum(col^2))
+    if (nrm > .Machine$double.eps) col / nrm else col
   })
   U_cos <- apply(U_cos_raw, 2, function(col) {
-    norm_val <- sqrt(sum(col^2))
-    if (norm_val > .Machine$double.eps) col / norm_val else col
+    nrm <- sqrt(sum(col^2))
+    if (nrm > .Machine$double.eps) col / nrm else col
   })
-  
-  # Ensure matrix structure is preserved after apply if only one column
+
   if (is.vector(U_sin)) U_sin <- matrix(U_sin, ncol = 1)
   if (is.vector(U_cos)) U_cos <- matrix(U_cos, ncol = 1)
 
-  # Ensure column names are unique if multiple frequencies are identical (should be rare with findpeaks)
-  colnames(U_sin) <- paste0("sin_f", sprintf("%.4f", selected_frequencies_hz))
-  colnames(U_cos) <- paste0("cos_f", sprintf("%.4f", selected_frequencies_hz))
-  
-  U_spectral_sines <- cbind(U_sin, U_cos)
+  colnames(U_sin) <- paste0("sin_f", sprintf("%.4f", freqs_hz))
+  colnames(U_cos) <- paste0("cos_f", sprintf("%.4f", freqs_hz))
 
-  attr(U_spectral_sines, "freq_hz") <- selected_frequencies_hz
-  attr(U_spectral_sines, "freq_rad_s") <- omega_rad_s
-
-  if (verbose) {
-    message(sprintf("Generated %d sine/cosine pairs from %d spectral peaks.",
-                    ncol(U_spectral_sines) / 2, length(selected_frequencies_hz)))
-  }
-
-  # Call Select_Significant_Spectral_Regressors
-  selected_regressors <- Select_Significant_Spectral_Regressors(
-    y = mean_residual_for_spectrum,
-    U_candidates = U_spectral_sines,
-    criterion = selection_criterion,
-    delta_threshold = selection_delta_threshold,
-    verbose = verbose
-  )
-
-  return(selected_regressors) # This will now be a 0-col matrix with attrs if none selected
-}
-
-#' Create an empty matrix for spectral regressors
-#'
-#' @keywords internal
-.empty_spec_matrix <- function(n_rows) {
-  res <- matrix(numeric(0), nrow = n_rows, ncol = 0,
-                dimnames = list(NULL, character(0)))
-  attr(res, "freq_hz") <- numeric(0)
-  attr(res, "freq_rad_s") <- numeric(0)
-  attr(res, "selected_pair_indices") <- integer(0)
-  res
+  U <- cbind(U_sin, U_cos)
+  attr(U, "freq_hz") <- freqs_hz
+  attr(U, "freq_rad_s") <- omega_rad_s
+  U
 }
 
 #' Select Spectral Regressors via Information Criterion

--- a/tests/testthat/test-spectral-helpers.R
+++ b/tests/testthat/test-spectral-helpers.R
@@ -1,0 +1,65 @@
+context("ndx_spectral_sines helpers")
+
+test_that(".validate_spectral_inputs centers data and enforces defaults", {
+  vec <- 1:10
+  res <- fmridenoise:::`.validate_spectral_inputs`(vec, TR = 1,
+                                                   n_sine_candidates = 2,
+                                                   selection_delta_threshold = 3)
+  expect_null(res$error)
+  expect_equal(sum(res$vec), 0)
+  expect_equal(res$n_sine_candidates, 2)
+  expect_equal(res$selection_delta_threshold, 3)
+
+  expect_warning(
+    res_bad <- fmridenoise:::`.validate_spectral_inputs`(vec, TR = 1,
+                                                        n_sine_candidates = -1,
+                                                        selection_delta_threshold = 1),
+    "n_sine_candidates"
+  )
+  expect_equal(res_bad$n_sine_candidates, 6)
+})
+
+test_that(".adjust_mtm_params constrains k_tapers and nw", {
+  adj <- fmridenoise:::`.adjust_mtm_params`(k_tapers = 10, nw = 2,
+                                            series_length = 20, verbose = FALSE)
+  expect_null(adj$error)
+  expect_equal(adj$nw, 2)
+  expect_equal(adj$k_tapers, 3)
+
+  adj_bad <- fmridenoise:::`.adjust_mtm_params`(k_tapers = 2, nw = 1,
+                                                series_length = 1, verbose = FALSE)
+  expect_true(is.matrix(adj_bad$error))
+  expect_equal(nrow(adj_bad$error), 1)
+})
+
+test_that(".estimate_spectrum produces spectrum or NULL on failure", {
+  ts <- sin(2 * pi * 0.1 * (0:99))
+  est <- fmridenoise:::`.estimate_spectrum`(ts, TR = 1, k_tapers = 3, nw = 2)
+  expect_true(!is.null(est))
+  expect_true(all(c("spec", "freq") %in% names(est)))
+
+  expect_warning(
+    est_bad <- fmridenoise:::`.estimate_spectrum`(rnorm(5), TR = 1,
+                                                 k_tapers = 5, nw = 3),
+    "spec.mtm"
+  )
+  expect_null(est_bad)
+})
+
+test_that(".find_spectral_peaks detects correct frequency", {
+  ts <- sin(2 * pi * 0.1 * (0:199))
+  est <- fmridenoise:::`.estimate_spectrum`(ts, TR = 1, k_tapers = 5, nw = 3)
+  freqs <- fmridenoise:::`.find_spectral_peaks`(est, TR = 1,
+                                                nyquist_guard_factor = 1,
+                                                n_sine_candidates = 1,
+                                                verbose = FALSE)
+  expect_true(length(freqs) >= 1)
+  expect_lt(abs(freqs[1] - 0.1), 0.01)
+})
+
+test_that(".build_sine_regressors constructs proper matrix", {
+  U <- fmridenoise:::`.build_sine_regressors`(0.1, series_length = 10, TR = 1)
+  expect_equal(dim(U), c(10, 2))
+  expect_equal(attr(U, "freq_hz"), 0.1)
+  expect_equal(colnames(U), c("sin_f0.1000", "cos_f0.1000"))
+})


### PR DESCRIPTION
## Summary
- refactor `ndx_spectral_sines` using new helper functions
- add `.validate_spectral_inputs`, `.adjust_mtm_params`, `.estimate_spectrum`, `.find_spectral_peaks`, and `.build_sine_regressors`
- unit tests for helpers

## Testing
- `Rscript run_tests.R` *(fails: command not found)*