### PR TITLE
Add tests for diagnostic plot helpers

### DIFF
--- a/R/ndx_diagnostic_plots.R
+++ b/R/ndx_diagnostic_plots.R
@@ -1,0 +1,121 @@
+# Helper functions for generating diagnostic plots as PNG files
+# These functions are internal and return the path to the generated file
+# or NULL if the plot could not be produced.
+
+#' Plot DES per pass and save to PNG
+#' @keywords internal
+ndx_plot_des_per_pass <- function(diagnostics_per_pass, output_dir) {
+  if (!is.list(diagnostics_per_pass) || length(diagnostics_per_pass) == 0) {
+    stop("diagnostics_per_pass must be a non-empty list")
+  }
+  des_vals <- vapply(diagnostics_per_pass, function(d) d$DES %||% NA_real_, numeric(1))
+  png_file <- file.path(output_dir, "des_per_pass.png")
+  if (!dir.exists(output_dir)) dir.create(output_dir, recursive = TRUE)
+  grDevices::png(png_file, width = 600, height = 400)
+  graphics::plot(seq_along(des_vals), des_vals, type = "b", xlab = "Pass", ylab = "DES",
+                 main = "Denoising Efficacy Score per Pass")
+  grDevices::dev.off()
+  png_file
+}
+
+#' Plot beta stability across passes
+#' @keywords internal
+ndx_plot_beta_stability <- function(beta_history_per_pass, output_dir) {
+  if (!is.list(beta_history_per_pass) || length(beta_history_per_pass) == 0) {
+    stop("beta_history_per_pass must be a non-empty list")
+  }
+  beta_vals <- calculate_beta_stability(beta_history_per_pass)
+  png_file <- file.path(output_dir, "beta_stability_per_pass.png")
+  if (!dir.exists(output_dir)) dir.create(output_dir, recursive = TRUE)
+  grDevices::png(png_file, width = 600, height = 400)
+  graphics::plot(seq_along(beta_vals), beta_vals, type = "b", xlab = "Pass",
+                 ylab = "Beta Stability", ylim = c(-1, 1),
+                 main = "\u03B2-Stability Across Runs")
+  grDevices::dev.off()
+  png_file
+}
+
+#' Plot residual PSD comparison
+#' @keywords internal
+ndx_plot_residual_psd <- function(pass0_residuals, final_residuals, TR, output_dir) {
+  if (!is.matrix(pass0_residuals) || !is.matrix(final_residuals)) {
+    stop("pass0_residuals and final_residuals must be matrices")
+  }
+  if (nrow(pass0_residuals) != nrow(final_residuals)) {
+    stop("Residual matrices must have the same number of rows")
+  }
+  if (!is.numeric(TR) || length(TR) != 1 || TR <= 0) {
+    stop("TR must be a positive numeric scalar")
+  }
+  res0_mean <- rowMeans(pass0_residuals, na.rm = TRUE)
+  res_final_mean <- rowMeans(final_residuals, na.rm = TRUE)
+  psd0 <- psd::pspectrum(res0_mean, x.frqsamp = 1/TR, plot = FALSE)
+  psdF <- psd::pspectrum(res_final_mean, x.frqsamp = 1/TR, plot = FALSE)
+  png_file <- file.path(output_dir, "residual_psd.png")
+  if (!dir.exists(output_dir)) dir.create(output_dir, recursive = TRUE)
+  grDevices::png(png_file, width = 600, height = 400)
+  graphics::plot(psd0$freq, psd0$spec, type = "l", col = "red", log = "y",
+                 xlab = "Frequency (Hz)", ylab = "PSD",
+                 main = "Residual Power Spectral Density")
+  graphics::lines(psdF$freq, psdF$spec, col = "blue")
+  graphics::legend("topright", legend = c("Pass 0", "Final"), col = c("red", "blue"), lty = 1, bty = "n")
+  grDevices::dev.off()
+  png_file
+}
+
+#' Plot Ljung-Box p-values per pass
+#' @keywords internal
+ndx_plot_ljung_box_pvalues <- function(diagnostics_per_pass, output_dir) {
+  if (!is.list(diagnostics_per_pass) || length(diagnostics_per_pass) == 0) {
+    stop("diagnostics_per_pass must be a non-empty list")
+  }
+  ljung_vals <- vapply(diagnostics_per_pass, function(d) d$ljung_box_p %||% NA_real_, numeric(1))
+  if (all(is.na(ljung_vals))) return(NULL)
+  png_file <- file.path(output_dir, "ljung_box_pvalues.png")
+  if (!dir.exists(output_dir)) dir.create(output_dir, recursive = TRUE)
+  grDevices::png(png_file, width = 600, height = 400)
+  graphics::plot(seq_along(ljung_vals), ljung_vals, type = "b", xlab = "Pass",
+                 ylab = "Ljung-Box p-value", ylim = c(0, 1),
+                 main = "Residual Whiteness (Ljung-Box)")
+  graphics::abline(h = 0.05, col = "red", lty = 2)
+  grDevices::dev.off()
+  png_file
+}
+
+#' Plot spike carpet from RPCA S matrix
+#' @keywords internal
+ndx_plot_spike_carpet <- function(S_matrix, output_dir) {
+  if (!is.matrix(S_matrix)) {
+    stop("S_matrix must be a matrix")
+  }
+  png_file <- file.path(output_dir, "spike_carpet.png")
+  if (!dir.exists(output_dir)) dir.create(output_dir, recursive = TRUE)
+  grDevices::png(png_file, width = 600, height = 400)
+  graphics::image(t(abs(S_matrix) > 0), axes = FALSE, useRaster = TRUE,
+                  xlab = "Time", ylab = "Voxel", main = "RPCA Spike Carpet")
+  graphics::box()
+  grDevices::dev.off()
+  png_file
+}
+
+#' Plot GLMdenoise R2 by k
+#' @keywords internal
+ndx_plot_gdlite_r2_by_k <- function(gdlite_diagnostics, output_dir) {
+  if (is.null(gdlite_diagnostics$r2_vals_by_k)) {
+    stop("gdlite_diagnostics must contain r2_vals_by_k")
+  }
+  r2_vals <- gdlite_diagnostics$r2_vals_by_k
+  optimal_k <- gdlite_diagnostics$optimal_k
+  png_file <- file.path(output_dir, "gdlite_r2_by_k.png")
+  if (!dir.exists(output_dir)) dir.create(output_dir, recursive = TRUE)
+  grDevices::png(png_file, width = 600, height = 400)
+  k_vals <- seq_along(r2_vals)
+  graphics::plot(k_vals, r2_vals, type = "b", col = "darkgreen", xlab = "Number of PCs (k)",
+                 ylab = "Cross-validated R2", main = "GLMdenoise-Lite: R2 by k")
+  if (!is.null(optimal_k) && optimal_k > 0 && optimal_k <= length(r2_vals)) {
+    graphics::points(optimal_k, r2_vals[optimal_k], pch = 19, col = "red", cex = 1.5)
+    graphics::text(optimal_k, r2_vals[optimal_k], labels = sprintf("k=%d", optimal_k), pos = 3, col = "red")
+  }
+  grDevices::dev.off()
+  png_file
+}

--- a/tests/testthat/test-diagnostic_plots.R
+++ b/tests/testthat/test-diagnostic_plots.R
@@ -1,0 +1,57 @@
+context("diagnostic plot helpers")
+
+# sample data for plots
+sample_diagnostics <- list(
+  list(DES = 0.1, ljung_box_p = 0.3),
+  list(DES = 0.2, ljung_box_p = 0.6)
+)
+
+sample_betas <- list(
+  list(matrix(rnorm(4), 2, 2), matrix(rnorm(4), 2, 2)),
+  list(matrix(rnorm(4), 2, 2), matrix(rnorm(4), 2, 2))
+)
+
+sample_pass0 <- matrix(rnorm(20), 10, 2)
+sample_final <- matrix(rnorm(20), 10, 2)
+
+sample_S <- matrix(rnorm(20), 10, 2)
+
+sample_gdlite <- list(r2_vals_by_k = c(0.1, 0.3, 0.4), optimal_k = 2)
+
+TR_test <- 2
+
+# ---- Successful cases ----
+
+test_that("plot helpers create pngs and return paths", {
+  outdir <- tempfile("plots")
+  dir.create(outdir)
+
+  des_path <- ndx:::ndx_plot_des_per_pass(sample_diagnostics, outdir)
+  expect_true(file.exists(des_path))
+
+  beta_path <- ndx:::ndx_plot_beta_stability(sample_betas, outdir)
+  expect_true(file.exists(beta_path))
+
+  psd_path <- ndx:::ndx_plot_residual_psd(sample_pass0, sample_final, TR_test, outdir)
+  expect_true(file.exists(psd_path))
+
+  ljung_path <- ndx:::ndx_plot_ljung_box_pvalues(sample_diagnostics, outdir)
+  expect_true(file.exists(ljung_path))
+
+  carpet_path <- ndx:::ndx_plot_spike_carpet(sample_S, outdir)
+  expect_true(file.exists(carpet_path))
+
+  gdlite_path <- ndx:::ndx_plot_gdlite_r2_by_k(sample_gdlite, outdir)
+  expect_true(file.exists(gdlite_path))
+})
+
+# ---- Edge cases ----
+
+test_that("plot helpers handle invalid input", {
+  expect_error(ndx:::ndx_plot_des_per_pass(list(), tempdir()))
+  expect_error(ndx:::ndx_plot_beta_stability(list(), tempdir()))
+  expect_error(ndx:::ndx_plot_residual_psd(matrix(1,2,2), matrix(1,3,2), TR_test, tempdir()))
+  expect_null(ndx:::ndx_plot_ljung_box_pvalues(list(list(ljung_box_p = NA_real_)), tempdir()))
+  expect_error(ndx:::ndx_plot_spike_carpet(1:5, tempdir()))
+  expect_error(ndx:::ndx_plot_gdlite_r2_by_k(list(), tempdir()))
+})


### PR DESCRIPTION
## Summary
- add helper functions to generate diagnostic plot PNGs
- cover new plot helpers with unit tests

## Testing
- `devtools::test()` *(fails: R not installed)*