### PR TITLE
Add tests for merge equivalence and annihilation verdict

### DIFF
--- a/tests/testthat/test-annihilation_verdict_integration.R
+++ b/tests/testthat/test-annihilation_verdict_integration.R
@@ -1,0 +1,61 @@
+context("NDX_Process_Subject - Annihilation verdict integration")
+
+test_that("Workflow outputs annihilation verdict when mode enabled", {
+  set.seed(42)
+  TR <- 1.5
+  n_time <- 30
+  n_vox <- 5
+  Y <- matrix(rnorm(n_time * n_vox), nrow = n_time, ncol = n_vox)
+  run_idx <- rep(1L, n_time)
+  motion <- matrix(rnorm(n_time * 3), nrow = n_time, ncol = 3)
+  colnames(motion) <- paste0("mot", 1:3)
+  events <- data.frame(
+    onsets = c(5, 15) * TR,
+    durations = c(3, 3) * TR,
+    condition = factor(c("A", "B")),
+    blockids = 1L
+  )
+
+  opts <- list(
+    opts_pass0 = list(poly_degree = 0),
+    opts_hrf = list(
+      hrf_fir_taps = 4,
+      hrf_fir_span_seconds = 6,
+      good_voxel_R2_threshold = -Inf,
+      lambda1_grid = c(0.1),
+      lambda2_grid = c(0.1),
+      cv_folds = 2,
+      hrf_min_good_voxels = 1,
+      hrf_cluster_method = "none",
+      num_hrf_clusters = 1
+    ),
+    opts_rpca = list(k_global_target = 2, rpca_lambda_auto = FALSE, rpca_lambda_fixed = 0.1, rpca_merge_strategy = "concat_svd"),
+    opts_spectral = list(n_sine_candidates = 1, nyquist_guard_factor = 0.1),
+    opts_whitening = list(global_ar_on_design = FALSE, max_ar_failures_prop = 0.5),
+    opts_ridge = list(lambda_ridge = 0.5),
+    opts_annihilation = list(
+      annihilation_enable_mode = TRUE,
+      annihilation_gdlite_k_max = 2,
+      annihilation_gdlite_tsnr_thresh_noise_pool = 0.5,
+      annihilation_gdlite_r2_thresh_noise_pool = 0.8,
+      min_K_optimal_selection = 0
+    ),
+    max_passes = 1,
+    min_des_gain_convergence = -Inf,
+    min_rho_noise_projection_convergence = -Inf
+  )
+
+  res <- NDX_Process_Subject(
+    Y_fmri = Y,
+    events = events,
+    motion_params = motion,
+    run_idx = run_idx,
+    TR = TR,
+    user_options = opts,
+    verbose = FALSE
+  )
+
+  expect_true(res$annihilation_mode_active)
+  expect_true(!is.null(res$annihilation_verdict))
+  expect_true(is.character(res$annihilation_verdict))
+})

--- a/tests/testthat/test-grassmann_merge.R
+++ b/tests/testthat/test-grassmann_merge.R
@@ -27,3 +27,26 @@ test_that("Merged matrix remains orthonormal", {
   expect_true(.is_orthonormal(merged, tol = 1e-6))
 })
 
+
+# Test equivalence of merging strategies
+
+test_that("iterative and concat_svd merge yield equivalent subspace", {
+  set.seed(123)
+  V1 <- qr.Q(qr(matrix(rnorm(60), 10)))[,1:3]
+  V2 <- qr.Q(qr(matrix(rnorm(60), 10)))[,1:3]
+  k_target <- 4
+
+  V_concat <- .ndx_basic_merge_voxel_components(list(V1, V2), k_target, strategy = "concat_svd")
+  V_iter <- .ndx_basic_merge_voxel_components(list(V1, V2), k_target, strategy = "iterative")
+
+  expect_equal(ncol(V_concat), k_target)
+  expect_equal(ncol(V_iter), k_target)
+  expect_equal(nrow(V_concat), 10)
+  expect_equal(nrow(V_iter), 10)
+
+  P_concat <- V_concat %*% t(V_concat)
+  P_iter <- V_iter %*% t(V_iter)
+  frob_diff <- norm(P_concat - P_iter, type = "F")
+  expect_lt(frob_diff, 1e-6)
+})
+


### PR DESCRIPTION
## Summary
- extend Grassmann merge tests to validate equivalence with concat+SVD
- check that the workflow produces an annihilation verdict when annihilation mode is active

## Testing
- `Rscript run_tests.R` *(fails: command not found)*