### PR TITLE
Remove global assignments

### DIFF
--- a/R/ndx_ridge.R
+++ b/R/ndx_ridge.R
@@ -492,14 +492,16 @@ solve_weighted_ridge <- function(Y_eff, X_eff, K_penalty_diag = NULL,
 
   betas <- NULL
   chol_decomp <- NULL
-  tryCatch({
+  solve_res <- tryCatch({
     chol_decomp <- chol(lhs)
     betas <- chol2inv(chol_decomp) %*% XtY
+    list(betas = betas, chol_decomp = chol_decomp)
   }, error = function(e) {
     warning(paste("Solving anisotropic ridge regression failed (Cholesky method):", e$message))
-    betas <<- NULL
-    chol_decomp <<- NULL
+    list(betas = NULL, chol_decomp = NULL)
   })
+  betas <- solve_res$betas
+  chol_decomp <- solve_res$chol_decomp
 
   if (is.null(betas)) {
     return(NULL)

--- a/R/ndx_rpca_helpers.R
+++ b/R/ndx_rpca_helpers.R
@@ -184,12 +184,11 @@
     run_name, nrow(Er_t), ncol(Er_t), k_this_run, lambda_r
   ))
 
-  rpca_res_r <- NULL
-  tryCatch({
-    rpca_res_r <- do.call(rpca, rpca_call_args)
+  rpca_res_r <- tryCatch({
+    do.call(rpca, rpca_call_args)
   }, error = function(e) {
     warning(sprintf("rpca::rpca failed for run %s: %s", run_name, e$message))
-    rpca_res_r <<- NULL
+    NULL
   })
 
   if (is.null(rpca_res_r) || is.null(rpca_res_r$L)) {
@@ -211,12 +210,11 @@
     ))
   }
 
-  svd_L_r_t <- NULL
-  tryCatch({
-    svd_L_r_t <- svd(L_r_t, nu = k_eff_svd_L, nv = 0)
+  svd_L_r_t <- tryCatch({
+    svd(L_r_t, nu = k_eff_svd_L, nv = 0)
   }, error = function(e) {
     warning(sprintf("SVD on L_r_t for run %s failed: %s", run_name, e$message))
-    svd_L_r_t <<- NULL
+    NULL
   })
 
   if (is.null(svd_L_r_t) || is.null(svd_L_r_t$u) || ncol(svd_L_r_t$u) == 0) {
@@ -313,12 +311,11 @@
       ))
       return(list(V_global = NULL, singular_values = NULL))
     }
-    svd_V_all <- NULL
-    tryCatch({
-      svd_V_all <- svd(V_all_concat, nu = k_for_svd_V_all, nv = 0)
+    svd_V_all <- tryCatch({
+      svd(V_all_concat, nu = k_for_svd_V_all, nv = 0)
     }, error = function(e) {
       warning(paste("SVD on concatenated V_r components for V_global failed:", e$message))
-      svd_V_all <<- NULL
+      NULL
     })
     if (is.null(svd_V_all) || is.null(svd_V_all$u) || ncol(svd_V_all$u) == 0) {
       warning("SVD on concatenated V_r for V_global failed to produce U vectors.")

--- a/R/ndx_whitening.R
+++ b/R/ndx_whitening.R
@@ -271,10 +271,10 @@ ndx_ar2_whitening <- function(Y_data, X_design_full, Y_residuals_for_AR_fit,
   phi <- rep(0, order)
   var_pred <- NA_real_
 
-  tryCatch({
+  ar_fit_res <- tryCatch({
     if (stats::var(voxel_residuals, na.rm = TRUE) > .Machine$double.eps^0.5) {
       if (is.null(weights_vec)) {
-        ar_fit <- stats::ar.yw(voxel_residuals, aic = FALSE, order.max = order)
+        stats::ar.yw(voxel_residuals, aic = FALSE, order.max = order)
       } else {
         embed_mat <- stats::embed(voxel_residuals, order + 1)
         y_ar <- embed_mat[, 1]
@@ -284,17 +284,22 @@ ndx_ar2_whitening <- function(Y_data, X_design_full, Y_residuals_for_AR_fit,
           fit <- tryCatch(stats::lm.wfit(x = X_ar, y = y_ar, w = w_ar),
                           error = function(e) NULL)
           if (!is.null(fit) && length(fit$coefficients) == order) {
-            ar_fit <- list(ar = as.numeric(fit$coefficients),
-                           var.pred = sum((fit$residuals^2) * w_ar) / sum(w_ar))
+            list(ar = as.numeric(fit$coefficients),
+                 var.pred = sum((fit$residuals^2) * w_ar) / sum(w_ar))
+          } else {
+            NULL
           }
+        } else {
+          NULL
         }
       }
     } else {
-      ar_fit <- NULL
+      NULL
     }
   }, error = function(e) {
-    ar_fit <<- NULL
+    NULL
   })
+  if (!is.null(ar_fit_res)) ar_fit <- ar_fit_res
 
   if (!is.null(ar_fit) && length(ar_fit$ar) == order) {
     phi_candidate <- ar_fit$ar

--- a/R/ndx_workflow.R
+++ b/R/ndx_workflow.R
@@ -135,17 +135,19 @@ NDX_Process_Subject <- function(Y_fmri,
     if (verbose) message(sprintf("\n--- Starting ND-X Pass %d/%d ---", pass_num, max_passes))
     
     # Run single pass with error handling
-    tryCatch({
-      workflow_state <- .ndx_run_single_pass(workflow_state, pass_num)
+    pass_result <- tryCatch({
+      list(state = .ndx_run_single_pass(workflow_state, pass_num))
     }, error = function(e) {
       if (verbose) message(sprintf("Pass %d failed with error: %s", pass_num, e$message))
       # Set a minimal current_pass_results if it doesn't exist
       if (is.null(workflow_state$current_pass_results)) {
-        workflow_state$current_pass_results <<- list()
+        workflow_state$current_pass_results <- list()
       }
       # Break out of the loop by setting Y_residuals_current to NULL
-      workflow_state$Y_residuals_current <<- NULL
+      workflow_state$Y_residuals_current <- NULL
+      list(state = workflow_state)
     })
+    workflow_state <- pass_result$state
     
     # Check for early termination
     if (is.null(workflow_state$Y_residuals_current)) {


### PR DESCRIPTION
## Summary
- refactor error handling in `.ndx_run_iterative_passes`
- handle failures in ridge regression, RPCA helpers and whitening without using global assignment

## Testing
- `Rscript run_tests.R` *(fails: `Rscript` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a2f548318832d91eed50a53da863f