### PR TITLE
Add roxygen docs for missing exports

### DIFF
--- a/R/ndx_diagnostics.R
+++ b/R/ndx_diagnostics.R
@@ -406,7 +406,7 @@ ndx_generate_html_report <- function(workflow_output,
 #' @param output_path File path to save the JSON sidecar. Defaults to
 #'   "sub-ndx.json" in the current working directory.
 #' @return Invisibly, the path to the written JSON file.
-#' @export ndx_generate_json_certificate
+#' @export
 ndx_generate_json_certificate <- function(workflow_output,
                                           output_path = "sub-ndx.json") {
   if (is.null(workflow_output) || !is.list(workflow_output)) {

--- a/R/ndx_precision_weights.R
+++ b/R/ndx_precision_weights.R
@@ -10,7 +10,7 @@
 #'   `S_matrix` are treated as zero (yielding a weight of one). Default `TRUE`.
 #' @return Numeric matrix of precision weights with the same dimensions as
 #'   `S_matrix`.
-#' @export ndx_precision_weights_from_S
+#' @export
 ndx_precision_weights_from_S <- function(S_matrix, mad_floor = 1e-6,
                                          na_zero = TRUE) {
   if (!is.matrix(S_matrix) || !is.numeric(S_matrix)) {

--- a/R/ndx_progressive_viz.R
+++ b/R/ndx_progressive_viz.R
@@ -286,6 +286,7 @@ create_stage_description_panel <- function() {
 }
 
 #' Add Progressive Enhancement Visualization to HTML Report
+#' Inserts a progressive enhancement visualization section into the diagnostic HTML report.
 #'
 #' @param html_lines Character vector of HTML lines for the report
 #' @param workflow_output List returned by NDX_Process_Subject

--- a/R/ndx_utils.R
+++ b/R/ndx_utils.R
@@ -306,6 +306,7 @@ merge_lists <- function(defaults, user) {
 #'
 #' @param a First value.
 #' @param b Fallback value.
+#' @return `a` if not `NULL`, otherwise `b`.
 #' @keywords internal
 #' @export
 `%||%` <- function(a, b) {

--- a/R/ndx_workflow_utils.R
+++ b/R/ndx_workflow_utils.R
@@ -8,6 +8,8 @@ NULL
 
 #' Validate inputs for `NDX_Process_Subject`
 #'
+#' Checks that input matrices and vectors have the correct types and dimensions before running the workflow.
+#'
 #' @param Y_fmri Numeric matrix of fMRI data.
 #' @param events Data frame of events.
 #' @param motion_params Numeric matrix of motion parameters.
@@ -50,6 +52,9 @@ ndx_validate_process_subject_inputs <- function(Y_fmri, events, motion_params,
 
 #' Merge user options with defaults
 #'
+#' Combines user-supplied workflow options with the ND-X defaults,
+#' filling in any unspecified values.
+#'
 #' @param user_options List of user supplied options.
 #' @return Named list of options where unspecified values are filled with defaults.
 #' @export
@@ -59,6 +64,8 @@ ndx_prepare_workflow_options <- function(user_options = list()) {
 }
 
 #' Run the optional GLMdenoise-Lite setup for Annihilation mode
+#'
+#' Executes a light-weight GLMdenoise procedure when Annihilation Mode is enabled. The selected principal components are returned along with the full GLMdenoise-Lite results.
 #'
 #' @param Y_fmri Numeric matrix of fMRI data.
 #' @param events Data frame of events.


### PR DESCRIPTION
## Summary
- document `%||%`, `ndx_generate_json_certificate`, `ndx_precision_weights_from_S`
- improve docs for workflow helpers

## Testing
- `Rscript -e "devtools::document()"` *(fails: `Rscript` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a344439d4832d9bafa7bdd8616473