### PR TITLE
Enable OpenMP for AR filters

### DIFF
--- a/src/apply_ar_filter.cpp
+++ b/src/apply_ar_filter.cpp
@@ -1,4 +1,9 @@
 #include <Rcpp.h>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+// [[Rcpp::plugins(openmp)]]
 using namespace Rcpp;
 
 // [[Rcpp::export]]
@@ -28,6 +33,7 @@ NumericMatrix apply_ar_filter_matrix_cpp(const NumericMatrix& M,
         return res;
     }
 
+    #pragma omp parallel for
     for (int col = 0; col < m; ++col) {
         for (int t = 0; t < p && t < n; ++t) {
             res(t, col) = NA_REAL;
@@ -53,6 +59,7 @@ NumericMatrix apply_ar_filter_voxelwise_cpp(const NumericMatrix& Y,
         stop("Coefficient matrix rows must equal number of columns in Y");
 
     NumericMatrix res(n, m);
+    #pragma omp parallel for
     for (int col = 0; col < m; ++col) {
         bool use_filter = false;
         for (int k = 0; k < p; ++k) {


### PR DESCRIPTION
## Summary
- add OpenMP plugin to AR filter code
- parallelize AR filter loops using `#pragma omp parallel for`

## Testing
- `Rscript tests/testthat/test-ar_filter_helpers.R` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846fe8e3474832d868a52afbc300151